### PR TITLE
First version of a lang tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+before_script:
+    - rustup toolchain install nightly
+    - rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
+script:
+    - cargo +nightly fmt --all -- --check
+    - cargo test --all
+    - cargo run --example=rust_lang_tester

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lang_tester"
+version = "0.1.0"
+authors = ["Laurence Tratt <laurie@tratt.net>"]
+edition = "2018"
+
+[[example]]
+name = "rust_lang_tester"
+path = "examples/rust_lang_tester/tester.rs"
+
+[dependencies]
+termcolor = "1.0"
+walkdir = "2"
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/examples/rust_lang_tester/lang_tests/no_main.rs
+++ b/examples/rust_lang_tester/lang_tests/no_main.rs
@@ -1,0 +1,10 @@
+// Compiler:
+//   status: error
+//   stderr:
+//     error[E0601]: `main` function not found in crate `no_main`
+//       |
+//       = note: consider adding a `main` function to `examples/rust_lang_tester/lang_tests/no_main.rs`
+//
+//     error: aborting due to previous error
+//
+//     For more information about this error, try `rustc --explain E0601`.

--- a/examples/rust_lang_tester/lang_tests/unknown_var.rs
+++ b/examples/rust_lang_tester/lang_tests/unknown_var.rs
@@ -1,0 +1,10 @@
+// Compiler:
+//   status: error
+//   stderr:
+//     error[E0425]: cannot find value `x` in this scope
+//      ...unknown_var.rs:9:20
+//      ...
+
+fn main() {
+    println!("{}", x);
+}

--- a/examples/rust_lang_tester/lang_tests/unused_var.rs
+++ b/examples/rust_lang_tester/lang_tests/unused_var.rs
@@ -1,0 +1,14 @@
+// Compiler:
+//   status: success
+//   stderr:
+//     warning: unused variable: `x`
+//       ...unused_var.rs:12:9
+//       ...
+//
+// Run-time:
+//   status: success
+//   stdout: Hello world
+fn main() {
+    let x = 0;
+    println!("Hello world");
+}

--- a/examples/rust_lang_tester/tester.rs
+++ b/examples/rust_lang_tester/tester.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+//! This is an example lang_tester for Rust: it is a simplified version of the test framework that
+//! rustc uses. In essence, the first sequence of commented line(s) (note that other lines e.g.
+//! `#![feature(...)]` lines and the like are skipped) in the file describe the test.
+//!
+//! See the test files in `lang_tests/` for example.
+
+use std::{path::PathBuf, process::Command};
+
+use lang_tester::LangTester;
+use tempdir::TempDir;
+
+fn main() {
+    // We use rustc to compile files into a binary: we store those binary files into `tempdir`.
+    // This may not be necessary for other languages.
+    let tempdir = TempDir::new("rust_lang_tester").unwrap();
+    LangTester::new()
+        .test_dir("examples/rust_lang_tester/lang_tests")
+        // Only use files named `*.rs` as tests.
+        .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
+        // Extract the first sequence of commented line(s) as the test.
+        .test_extract(|s| {
+            Some(
+                s.lines()
+                    // Skip non-commented lines at the start of the file.
+                    .skip_while(|l| !l.starts_with("//"))
+                    // Extract consecutive commented lines.
+                    .take_while(|l| l.starts_with("//"))
+                    .map(|l| &l[2..])
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        })
+        // We have two test commands:
+        //   * `Compiler`: runs rustc.
+        //   * `Run-time`: if rustc does not error, and the `Compiler` tests succeed, then the
+        //     output binary is run.
+        .test_cmds(move |p| {
+            // Test command 1: Compile `x.rs` into `tempdir/x`.
+            let mut exe = PathBuf::new();
+            exe.push(&tempdir);
+            exe.push(p.file_stem().unwrap());
+            let mut compiler = Command::new("rustc");
+            compiler.args(&["-o", exe.to_str().unwrap(), p.to_str().unwrap()]);
+            // Test command 2: run `tempdir/x`.
+            let runtime = Command::new(exe);
+            vec![("Compiler", compiler), ("Run-time", runtime)]
+        })
+        .run();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+//! This crate provide a simple language testing framework designed to help when you are testing
+//! things like compilers and virtual machines. It allows users to embed simple tests for process
+//! success/failure and for stderr/stdout inside a source file. It is loosely based on the
+//! [`compiletest_rs`](https://crates.io/crates/compiletest_rs) crate, but is much simpler (and
+//! hence sometimes less powerful), and designed to be used for testing non-Rust languages too.
+//!
+//! For example, a Rust language tester, loosely in the spirit of
+//! [`compiletest_rs`](https://crates.io/crates/compiletest_rs), looks as follows:
+//!
+//! ```rust
+//! use std::{path::PathBuf, process::Command};
+//!
+//! use lang_tester::LangTester;
+//! use tempdir::TempDir;
+//!
+//! fn main() {
+//!     // We use rustc to compile files into a binary: we store those binary files into `tempdir`.
+//!     // This may not be necessary for other languages.
+//!     let tempdir = TempDir::new("rust_lang_tester").unwrap();
+//!     LangTester::new()
+//!         .test_dir("examples/rust_lang_tester/lang_tests")
+//!         // Only use files named `*.rs` as tests.
+//!         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
+//!         // Extract the first sequence of commented line(s) as the test.
+//!         .test_extract(|s| {
+//!             Some(
+//!                 s.lines()
+//!                     // Skip non-commented lines at the start of the file.
+//!                     .skip_while(|l| !l.starts_with("//"))
+//!                     // Extract consecutive commented lines.
+//!                     .take_while(|l| l.starts_with("//"))
+//!                     .map(|l| &l[2..])
+//!                     .collect::<Vec<_>>()
+//!                     .join("\n"),
+//!             )
+//!         })
+//!         // We have two test commands:
+//!         //   * `Compiler`: runs rustc.
+//!         //   * `Run-time`: if rustc does not error, and the `Compiler` tests succeed, then the
+//!         //     output binary is run.
+//!         .test_cmds(move |p| {
+//!             // Test command 1: Compile `x.rs` into `tempdir/x`.
+//!             let mut exe = PathBuf::new();
+//!             exe.push(&tempdir);
+//!             exe.push(p.file_stem().unwrap());
+//!             let mut compiler = Command::new("rustc");
+//!             compiler.args(&["-o", exe.to_str().unwrap(), p.to_str().unwrap()]);
+//!             // Test command 2: run `tempdir/x`.
+//!             let runtime = Command::new(exe);
+//!             vec![("Compiler", compiler), ("Run-time", runtime)]
+//!         })
+//!         .run();
+//! }
+//! ```
+//!
+//! This defines a lang tester that uses all `*.rs` files in a given directory as tests, running
+//! two commands against them: `Compiler` (i.e. `rustc`); and `Run-time` (the compiled binary).
+//!
+//! Users can then write files with tests and their inputs such as the following:
+//!
+//! ```rust,ignore
+//! // Compiler:
+//! //   status: success
+//! //   stderr:
+//! //     warning: unused variable: `x`
+//! //       ...unused_var.rs:12:9
+//! //       ...
+//! //
+//! // Run-time:
+//! //   status: success
+//! //   stdout: Hello world
+//! fn main() {
+//!     let x = 0;
+//!     println!("Hello world");
+//! }
+//! ```
+//!
+//! Tests use a two-level indentation syntax: the outer most level of indentation defines a command
+//! name (multiple command names can be specified, as in the above); each command name can then
+//! define tests for one or more of `status: <success|failure>`, `stderr: [<string>]`, `stdout:
+//! [<string>]`.
+//!
+//! In essence, each keyword under a command name is a test for that command. The above file
+//! contains 4 tests: the `Compiler` should succeed (e.g. return a `0` exit code when run on Unix),
+//! and its `stderr` output should warn about an unused variable on line 12; and the resulting
+//! binary should succeed and produce `Hello world` on `stdout`.
+//!
+//! Lines not mentioned are not tested: for example, the above file does not state whether the
+//! `Compiler`s `stdout` should have content or not (but note that the line `stdout:` on its own
+//! would state that the `Compiler` should have no content at all). `stderr`/`stdout` tests can use
+//! `...` as a simple wildcard: if a line consists solely of `...`, it means either "match zero or
+//! more lines"; if a line begins with `...`, it means "match the remainder of the line only".
+
+mod parser;
+mod tester;
+
+pub use tester::LangTester;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use std::collections::hash_map::{Entry, HashMap};
+
+use crate::tester::Test;
+
+/// Parse test input into a set of `Test`s.
+pub(crate) fn parse_tests<'a>(test_str: &'a str) -> HashMap<String, Test<'a>> {
+    let lines = test_str.lines().collect::<Vec<_>>();
+    let mut tests = HashMap::new();
+    let mut line_off = 0;
+    while line_off < lines.len() {
+        let indent = indent_level(&lines, line_off);
+        if indent == lines[line_off].len() {
+            line_off += 1;
+            continue;
+        }
+        let (test_name, val) = key_val(&lines, line_off, indent);
+        if !val.is_empty() {
+            panic!(
+                "Test name '{}' can't have a value on line {}.",
+                test_name, line_off
+            );
+        }
+        match tests.entry(test_name.to_lowercase()) {
+            Entry::Occupied(_) => panic!(
+                "Command name '{}' is specified more than once, line {}.",
+                test_name, line_off
+            ),
+            Entry::Vacant(e) => {
+                line_off += 1;
+                let mut test = Test {
+                    status: None,
+                    stderr: None,
+                    stdout: None,
+                };
+                while line_off < lines.len() {
+                    let sub_indent = indent_level(&lines, line_off);
+                    if sub_indent == lines[line_off].len() {
+                        line_off += 1;
+                        continue;
+                    }
+                    if sub_indent == indent {
+                        break;
+                    }
+                    let (end_line_off, key, val) = key_multiline_val(&lines, line_off, sub_indent);
+                    line_off = end_line_off;
+                    match key {
+                        "status" => {
+                            let val_str = val.join("\n");
+                            let v_lower = val_str.to_lowercase();
+                            if v_lower != "success" && v_lower != "error" {
+                                panic!("Unknown status '{}' on line {}", val_str, line_off);
+                            }
+                            test.status = Some(v_lower);
+                        }
+                        "stderr" => {
+                            test.stderr = Some(val);
+                        }
+                        "stdout" => {
+                            test.stdout = Some(val);
+                        }
+                        _ => panic!("Unknown key '{}' on line {}.", key, line_off),
+                    }
+                }
+                e.insert(test);
+            }
+        }
+    }
+    tests
+}
+
+fn indent_level(lines: &Vec<&str>, line_off: usize) -> usize {
+    lines[line_off]
+        .chars()
+        .take_while(|c| c.is_whitespace())
+        .count()
+}
+
+/// Turn a line such as `key: val` into its separate components.
+fn key_val<'a>(lines: &Vec<&'a str>, line_off: usize, indent: usize) -> (&'a str, &'a str) {
+    let line = lines[line_off];
+    let key_len = line[indent..]
+        .chars()
+        .take_while(|c| !(c.is_whitespace() || c == &':'))
+        .count();
+    let key = &line[indent..indent + key_len];
+    let mut content_start = indent + key_len;
+    content_start += line[content_start..]
+        .chars()
+        .take_while(|c| c.is_whitespace())
+        .count();
+    match line[content_start..].chars().nth(0) {
+        Some(':') => content_start += ':'.len_utf8(),
+        _ => panic!("Invalid key terminator at line {}.\n  {}", line_off, line),
+    }
+    content_start += line[content_start..]
+        .chars()
+        .take_while(|c| c.is_whitespace())
+        .count();
+    (key, &line[content_start..])
+}
+
+/// Turn one more lines of the format `key: val` (where `val` may spread over many lines) into its
+/// separate components.
+fn key_multiline_val<'a>(
+    lines: &Vec<&'a str>,
+    mut line_off: usize,
+    indent: usize,
+) -> (usize, &'a str, Vec<&'a str>) {
+    let (key, first_line_val) = key_val(lines, line_off, indent);
+    line_off += 1;
+    if line_off == lines.len() {
+        return (line_off, key, vec![first_line_val.trim()]);
+    }
+    let mut val = Vec::new();
+    if !first_line_val.is_empty() {
+        val.push(first_line_val.trim());
+    }
+    let sub_indent = indent_level(lines, line_off);
+    while line_off < lines.len() {
+        let cur_indent = indent_level(lines, line_off);
+        if cur_indent == lines[line_off].len() {
+            val.push("");
+            line_off += 1;
+            continue;
+        }
+        if cur_indent <= indent {
+            break;
+        }
+        val.push(&lines[line_off][sub_indent..].trim());
+        line_off += 1;
+    }
+    while !val.is_empty() {
+        if !val[val.len() - 1].is_empty() {
+            break;
+        }
+        val.pop().unwrap();
+    }
+    (line_off, key, val)
+}

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -1,0 +1,418 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use std::{
+    collections::{hash_map::HashMap, HashSet},
+    fs::read_to_string,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{self, Command},
+};
+
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use walkdir::WalkDir;
+
+use crate::parser::parse_tests;
+
+const WILDCARD: &'static str = "...";
+
+pub struct LangTester<'a> {
+    test_dir: Option<&'a str>,
+    test_file_filter: Option<Box<Fn(&Path) -> bool>>,
+    test_extract: Option<Box<Fn(&str) -> Option<String>>>,
+    test_cmds: Option<Box<Fn(&Path) -> Vec<(&str, Command)>>>,
+}
+
+impl<'a> LangTester<'a> {
+    /// Create a new `LangTester` with default options. Note that, at a minimum, you need to call
+    /// [`test_dir`](#method.test_dir), [`test_extract`](#method.test_extract), and
+    /// [`test_cmds`](#method.test_cmds).
+    pub fn new() -> Self {
+        LangTester {
+            test_dir: None,
+            test_file_filter: None,
+            test_extract: None,
+            test_cmds: None,
+        }
+    }
+
+    /// Specify the directory where tests are contained in. Note that this directory will be
+    /// searched recursively (i.e. subdirectories and their contents will also be considered as
+    /// potential tests).
+    pub fn test_dir(&'a mut self, test_dir: &'a str) -> &'a mut Self {
+        self.test_dir = Some(test_dir);
+        self
+    }
+
+    /// If `test_file_filter` is specified, only files for which it returns `true` will be
+    /// considered tests. A common use of this is to filter files based on filename extensions
+    /// e.g.:
+    ///
+    /// ```rust,ignore
+    /// LangTester::new()
+    ///     ...
+    ///     .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
+    ///     ...
+    /// ```
+    pub fn test_file_filter<F>(&'a mut self, test_file_filter: F) -> &'a mut Self
+    where
+        F: 'static + Fn(&Path) -> bool,
+    {
+        self.test_file_filter = Some(Box::new(test_file_filter));
+        self
+    }
+
+    /// Specify a function which can extract the test data for `lang_tester` from a test file. This
+    /// function is passed a `&str` and must return a `String`.
+    ///
+    /// How the test is extracted from the file is entirely up to the user, though a common
+    /// convention is to store the test in a comment at the beginning of the file. For example, for
+    /// Rust code one could use a function along the lines of the following:
+    ///
+    /// ```rust,ignore
+    /// LangTester::new()
+    ///     ...
+    ///     .test_extract(|s| {
+    ///         Some(
+    ///             s.lines()
+    ///                 // Skip non-commented lines at the start of the file.
+    ///                 .skip_while(|l| !l.starts_with("//"))
+    ///                 // Extract consecutive commented lines.
+    ///                 .take_while(|l| l.starts_with("//"))
+    ///                 .map(|l| &l[2..])
+    ///                 .collect::<Vec<_>>()
+    ///                 .join("\n"),
+    ///         )
+    ///     })
+    ///     ...
+    /// ```
+    pub fn test_extract<F>(&'a mut self, test_extract: F) -> &'a mut Self
+    where
+        F: 'static + Fn(&str) -> Option<String>,
+    {
+        self.test_extract = Some(Box::new(test_extract));
+        self
+    }
+
+    /// Specify a function which takes a `Path` to a test file and returns a vector containing 1 or
+    /// more `(<name>, <[Command](https://doc.rust-lang.org/std/process/struct.Command.html)>)
+    /// pairs. The commands will be executed in order on the test file: for each executed command,
+    /// tests starting with `<name>` will be checked. For example, if your pipeline requires
+    /// separate compilation and linking, you might specify something along the lines of the
+    /// following:
+    ///
+    /// ```rust,ignore
+    /// let tempdir = ...; // A `Path` to a temporary directory.
+    /// LangTester::new()
+    ///     ...
+    ///     .test_cmds(|p| {
+    ///         let mut exe = PathBuf::new();
+    ///         exe.push(&tempdir);
+    ///         exe.push(p.file_stem().unwrap());
+    ///         let mut compiler = Command::new("rustc");
+    ///         compiler.args(&["-o", exe.to_str().unwrap(), p.to_str().unwrap()]);
+    ///         let runtime = Command::new(exe);
+    ///         vec![("Compiler", compiler), ("Run-time", runtime)]
+    ///     })
+    ///     ...
+    /// ```
+    ///
+    /// and then have tests such as:
+    ///
+    /// ```text
+    /// Compiler:
+    ///   status: success
+    ///   stderr:
+    ///   stdout:
+    ///
+    /// Run-time:
+    ///   status: failure
+    ///   stderr:
+    ///     ...
+    ///     Error at line 10
+    ///     ...
+    /// ```
+    pub fn test_cmds<F>(&'a mut self, test_cmds: F) -> &'a mut Self
+    where
+        F: 'static + Fn(&Path) -> Vec<(&str, Command)>,
+    {
+        self.test_cmds = Some(Box::new(test_cmds));
+        self
+    }
+
+    /// Make sure the user has specified the minimum set of things we need from them.
+    fn validate(&self) {
+        if self.test_dir.is_none() {
+            panic!("test_dir must be specified.");
+        }
+        if self.test_extract.is_none() {
+            panic!("test_extract must be specified.");
+        }
+        if self.test_cmds.is_none() {
+            panic!("test_cmds must be specified.");
+        }
+    }
+
+    /// Enumerate all the test files we need to check.
+    fn test_files(&self) -> Vec<PathBuf> {
+        WalkDir::new(self.test_dir.unwrap())
+            .into_iter()
+            .filter_map(|x| x.ok())
+            .filter(|x| x.file_type().is_file())
+            .filter(|x| match self.test_file_filter.as_ref() {
+                Some(f) => f(x.path()),
+                None => true,
+            })
+            .map(|x| x.into_path())
+            .collect()
+    }
+
+    /// Run all the lang tests.
+    pub fn run(&mut self) {
+        self.validate();
+        let test_files = self.test_files();
+        eprint!("\nrunning {} tests", test_files.len());
+        let mut failures = Vec::new();
+        let mut num_ignored = 0;
+        'b: for p in &test_files {
+            let test_name = p.file_stem().unwrap().to_str().unwrap();
+            eprint!("\ntest lang_tests::{} ... ", test_name);
+            let all_str =
+                read_to_string(p.as_path()).expect(&format!("Couldn't read {}", test_name));
+            let test_str = self.test_extract.as_ref().unwrap()(&all_str)
+                .expect(&format!("Couldn't extract test string from {}", test_name));
+            if test_str.trim().is_empty() {
+                write_with_colour("ignored", Color::Yellow);
+                eprint!(" (test string is empty)");
+                num_ignored += 1;
+                continue;
+            }
+
+            let tests = parse_tests(&test_str);
+            let cmd_pairs = self.test_cmds.as_mut().unwrap()(p.as_path())
+                .into_iter()
+                .map(|(test_name, cmd)| (test_name.to_lowercase(), cmd))
+                .collect::<Vec<_>>();
+            self.check_names(&cmd_pairs, &tests);
+
+            let mut failure = TestFailure {
+                status: None,
+                stderr: None,
+                stdout: None,
+            };
+            for (cmd_name, mut cmd) in cmd_pairs {
+                let output = cmd
+                    .output()
+                    .expect(&format!("Couldn't run command {:?}.", cmd));
+
+                let test = match tests.get(&cmd_name) {
+                    Some(t) => t,
+                    None => continue,
+                };
+                let mut meant_to_error = false;
+                if let Some(ref status) = test.status {
+                    if status == "error" {
+                        meant_to_error = true;
+                    }
+                    if output.status.success() && status == "error" {
+                        failure.status = Some("Success".to_owned());
+                    } else if !output.status.success() && status == "success" {
+                        failure.status = Some("Error".to_owned());
+                    }
+                }
+                if let Some(ref stderr) = test.stderr {
+                    let stderr_utf8 = String::from_utf8(output.stderr).unwrap();
+                    if !fuzzy_match(stderr, &stderr_utf8) {
+                        failure.stderr = Some(stderr_utf8);
+                    }
+                }
+                if let Some(ref stdout) = test.stdout {
+                    let stdout_utf8 = String::from_utf8(output.stdout).unwrap();
+                    if !fuzzy_match(stdout, &stdout_utf8) {
+                        failure.stdout = Some(stdout_utf8);
+                    }
+                }
+                if !output.status.success() && meant_to_error {
+                    break;
+                }
+            }
+
+            if failure
+                != (TestFailure {
+                    status: None,
+                    stderr: None,
+                    stdout: None,
+                })
+            {
+                failures.push((test_name, failure));
+                output_failed();
+            } else {
+                output_ok();
+            }
+        }
+
+        self.pp_failures(&failures, test_files.len(), num_ignored);
+
+        if !failures.is_empty() {
+            process::exit(1);
+        }
+    }
+
+    /// Check for the case where the user has a test called `X` but `test_cmds` doesn't have a
+    /// command with a matching name. This is almost certainly a bug, in the sense that the test
+    /// can never, ever fire.
+    fn check_names(&self, cmd_pairs: &Vec<(String, Command)>, tests: &HashMap<String, Test>) {
+        let cmd_names = cmd_pairs.iter().map(|x| &x.0).collect::<HashSet<_>>();
+        let test_names = tests.keys().map(|x| x).collect::<HashSet<_>>();
+        let diff = test_names
+            .difference(&cmd_names)
+            .map(|x| x.as_str())
+            .collect::<Vec<_>>();
+        if !diff.is_empty() {
+            panic!(
+                "Command name(s) '{}' in tests are not found in the actual commands.",
+                diff.join(", ")
+            );
+        }
+    }
+
+    /// Pretty print any failures to `stderr`.
+    fn pp_failures(
+        &self,
+        failures: &Vec<(&str, TestFailure)>,
+        test_files_len: usize,
+        num_ignored: usize,
+    ) {
+        if !failures.is_empty() {
+            eprintln!("\n\nfailures:");
+            for (test_name, test) in failures {
+                if let Some(ref status) = test.status {
+                    eprintln!("\n---- lang_tests::{} status ----\n{}", test_name, status);
+                }
+                if let Some(ref stderr) = test.stderr {
+                    eprintln!("\n---- lang_tests::{} stderr ----\n{}\n", test_name, stderr);
+                }
+                if let Some(ref stdout) = test.stdout {
+                    eprintln!("\n---- lang_tests::{} stdout ----\n{}\n", test_name, stdout);
+                }
+            }
+            eprintln!("\nfailures:");
+            for (test_name, _) in failures {
+                eprint!("    lang_tests::{}", test_name);
+            }
+        }
+
+        eprint!("\n\ntest result: ");
+        if failures.is_empty() {
+            output_ok();
+        } else {
+            output_failed();
+        }
+        eprintln!(
+            ". {} passed; {} failed; {} ignored; 0 measured; 0 filtered out\n",
+            test_files_len - failures.len(),
+            failures.len(),
+            num_ignored
+        );
+    }
+}
+
+/// A user `Test`.
+#[derive(Debug)]
+pub(crate) struct Test<'a> {
+    pub status: Option<String>,
+    pub stderr: Option<Vec<&'a str>>,
+    pub stdout: Option<Vec<&'a str>>,
+}
+
+/// If a test fails, the parts that fail are set to `Some(...)` in an instance of this struct.
+#[derive(Debug, PartialEq)]
+struct TestFailure {
+    status: Option<String>,
+    stderr: Option<String>,
+    stdout: Option<String>,
+}
+
+fn write_with_colour(s: &str, colour: Color) {
+    let mut stderr = StandardStream::stderr(ColorChoice::Always);
+    stderr.set_color(ColorSpec::new().set_fg(Some(colour))).ok();
+    io::stderr().write_all(s.as_bytes()).ok();
+    stderr.reset().ok();
+}
+
+fn output_failed() {
+    write_with_colour("FAILED", Color::Red);
+}
+
+fn output_ok() {
+    write_with_colour("ok", Color::Green);
+}
+
+/// Does `s` conform to the fuzzy pattern `pattern`? Note that `plines` is expected not to start or
+/// end with blank lines, and each line is expected to be `trim`ed.
+fn fuzzy_match(plines: &Vec<&str>, s: &str) -> bool {
+    let slines = s.trim().lines().map(|x| x.trim()).collect::<Vec<_>>();
+
+    let mut pi = 0;
+    let mut si = 0;
+
+    while pi < plines.len() && si < slines.len() {
+        if plines[pi] == WILDCARD {
+            pi += 1;
+            if pi == plines.len() {
+                return true;
+            }
+            if plines[pi] == WILDCARD {
+                panic!("Can't have '{}' on two consecutive lines.", WILDCARD);
+            }
+            while si < slines.len() {
+                if plines[pi] == slines[si] {
+                    break;
+                }
+                si += 1;
+            }
+            if si == slines.len() {
+                return false;
+            }
+        } else if (plines[pi].starts_with(WILDCARD)
+            && slines[si].ends_with(plines[pi][WILDCARD.len()..].trim()))
+            || plines[pi] == slines[si]
+        {
+            pi += 1;
+            si += 1;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuzzy_match() {
+        fn fuzzy_match_helper(p: &str, s: &str) -> bool {
+            fuzzy_match(&p.lines().collect::<Vec<_>>(), s)
+        }
+        assert!(fuzzy_match_helper("", ""));
+        assert!(fuzzy_match_helper("", "\n"));
+        assert!(fuzzy_match_helper("\n", "\n"));
+        assert!(fuzzy_match_helper("a", "a"));
+        assert!(fuzzy_match_helper("a", "a"));
+        assert!(fuzzy_match_helper("...\na", "a"));
+        assert!(fuzzy_match_helper("...\na\n...", "a"));
+        assert!(fuzzy_match_helper("a\n...", "a"));
+        assert!(fuzzy_match_helper("a\n...\nd", "a\nd"));
+        assert!(fuzzy_match_helper("a\n...\nd", "a\nb\nc\nd"));
+        assert!(!fuzzy_match_helper("a\n...\nd", "a\nb\nc"));
+        assert!(fuzzy_match_helper("a\n...\nc\n...\ne", "a\nb\nc\nd\ne"));
+    }
+}


### PR DESCRIPTION
This is a heavy rewrite of the preview from a day or two back, though the external API is mostly unchanged. The good news is that this is powerful enough to deal with both Rust and SOM tests, and to do so requiring very little code from the user of the library.

What has changed significantly since you last saw things is the internal code and the format of the tests themselves. I moved from a custom parser to YAML, but that was horrible: multi-line, nested YAML simply doesn't work as I expect, and the Rust YAML parser gives confusing error messages. I've thus moved to TOML. Is this a good idea? I'm wondering if the best syntax would, regrettably, be a custom indentation (almost YAML, but not quite) one:

```
// Compiler:
//     status: success
//     stderr:
//         warning: unused variable: `x`
//         ...unused_var.rs:13:9
//         ...
//
// Run-time:
//     status: success
//     stdout: Hello world
```

Feedback on that aspect welcome!

If you want to try this out, the easiest thing to do is run:

```sh
$ cargo run --example=rust_lang_tester
   Compiling lang_tester v0.1.0 (/home/ltratt/scratch/softdev/lang_tester)
    Finished dev [unoptimized + debuginfo] target(s) in 2.48s
     Running `target/debug/examples/rust_lang_tester`

running 3 tests
test lang_tests::no_main ... ok
test lang_tests::unknown_var ... ok
test lang_tests::unused_var ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

and then play with the test files in `examples/rust_lang_tester` ([here's the relevant file in the diff](https://github.com/softdevteam/lang_tester/pull/1/files#diff-31c7fec71a87b4badb3b56d964f5d675)), breaking them and so on.

Until we've confirmed what the test format should be, I'm going to hold off documenting the top-level of the library. But I don't think we're *too* far away from having something useful here.