### PR TITLE
Better fuzzy matching

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -45,6 +45,8 @@ pub(crate) fn match_vec(plines: &Vec<&str>, s: &str) -> bool {
     true
 }
 
+/// Does the line `s` match the pattern `p`? Note that both strings are expected to be trimed
+/// before being passed to this function.
 fn match_line(p: &str, s: &str) -> bool {
     (p.starts_with(WILDCARD) && s.ends_with(&p[WILDCARD.len()..])) || p == s
 }
@@ -59,10 +61,8 @@ mod tests {
             match_vec(&p.lines().collect::<Vec<_>>(), s)
         }
         assert!(match_vec_helper("", ""));
-        assert!(match_vec_helper("", "\n"));
-        assert!(match_vec_helper("\n", "\n"));
         assert!(match_vec_helper("a", "a"));
-        assert!(match_vec_helper("a", "a"));
+        assert!(!match_vec_helper("a", "ab"));
         assert!(match_vec_helper("...\na", "a"));
         assert!(match_vec_helper("...\na\n...", "a"));
         assert!(match_vec_helper("a\n...", "a"));

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+const WILDCARD: &'static str = "...";
+
+/// Does `s` conform to the fuzzy pattern `pattern`? Note that `plines` is expected not to start or
+/// end with blank lines, and each line is expected to be `trim`ed.
+pub(crate) fn match_vec(plines: &Vec<&str>, s: &str) -> bool {
+    let slines = s.trim().lines().map(|x| x.trim()).collect::<Vec<_>>();
+
+    let mut pi = 0;
+    let mut si = 0;
+
+    while pi < plines.len() && si < slines.len() {
+        if plines[pi] == WILDCARD {
+            pi += 1;
+            if pi == plines.len() {
+                return true;
+            }
+            if plines[pi] == WILDCARD {
+                panic!("Can't have '{}' on two consecutive lines.", WILDCARD);
+            }
+            while si < slines.len() {
+                if plines[pi] == slines[si] {
+                    break;
+                }
+                si += 1;
+            }
+            if si == slines.len() {
+                return false;
+            }
+        } else if (plines[pi].starts_with(WILDCARD)
+            && slines[si].ends_with(plines[pi][WILDCARD.len()..].trim()))
+            || plines[pi] == slines[si]
+        {
+            pi += 1;
+            si += 1;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_match_vec() {
+        fn match_vec_helper(p: &str, s: &str) -> bool {
+            match_vec(&p.lines().collect::<Vec<_>>(), s)
+        }
+        assert!(match_vec_helper("", ""));
+        assert!(match_vec_helper("", "\n"));
+        assert!(match_vec_helper("\n", "\n"));
+        assert!(match_vec_helper("a", "a"));
+        assert!(match_vec_helper("a", "a"));
+        assert!(match_vec_helper("...\na", "a"));
+        assert!(match_vec_helper("...\na\n...", "a"));
+        assert!(match_vec_helper("a\n...", "a"));
+        assert!(match_vec_helper("a\n...\nd", "a\nd"));
+        assert!(match_vec_helper("a\n...\nd", "a\nb\nc\nd"));
+        assert!(!match_vec_helper("a\n...\nd", "a\nb\nc"));
+        assert!(match_vec_helper("a\n...\nc\n...\ne", "a\nb\nc\nd\ne"));
+    }
+}

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -27,7 +27,7 @@ pub(crate) fn match_vec(plines: &Vec<&str>, s: &str) -> bool {
                 panic!("Can't have '{}' on two consecutive lines.", WILDCARD);
             }
             while si < slines.len() {
-                if plines[pi] == slines[si] {
+                if match_line(plines[pi], slines[si]) {
                     break;
                 }
                 si += 1;
@@ -35,10 +35,7 @@ pub(crate) fn match_vec(plines: &Vec<&str>, s: &str) -> bool {
             if si == slines.len() {
                 return false;
             }
-        } else if (plines[pi].starts_with(WILDCARD)
-            && slines[si].ends_with(plines[pi][WILDCARD.len()..].trim()))
-            || plines[pi] == slines[si]
-        {
+        } else if match_line(plines[pi], slines[si]) {
             pi += 1;
             si += 1;
         } else {
@@ -46,6 +43,10 @@ pub(crate) fn match_vec(plines: &Vec<&str>, s: &str) -> bool {
         }
     }
     true
+}
+
+fn match_line(p: &str, s: &str) -> bool {
+    (p.starts_with(WILDCARD) && s.ends_with(&p[WILDCARD.len()..])) || p == s
 }
 
 #[cfg(test)]
@@ -69,5 +70,6 @@ mod tests {
         assert!(match_vec_helper("a\n...\nd", "a\nb\nc\nd"));
         assert!(!match_vec_helper("a\n...\nd", "a\nb\nc"));
         assert!(match_vec_helper("a\n...\nc\n...\ne", "a\nb\nc\nd\ne"));
+        assert!(match_vec_helper("a\n...\n...b", "a\nb"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 //! `...` as a simple wildcard: if a line consists solely of `...`, it means either "match zero or
 //! more lines"; if a line begins with `...`, it means "match the remainder of the line only".
 
+mod fuzzy;
 mod parser;
 mod tester;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,11 @@
 //! Lines not mentioned are not tested: for example, the above file does not state whether the
 //! `Compiler`s `stdout` should have content or not (but note that the line `stdout:` on its own
 //! would state that the `Compiler` should have no content at all). `stderr`/`stdout` tests can use
-//! `...` as a simple wildcard: if a line consists solely of `...`, it means either "match zero or
-//! more lines"; if a line begins with `...`, it means "match the remainder of the line only".
+//! `...` as a simple wildcard: if a line consists solely of `...`, it means "match zero or
+//! more lines"; if a line begins with `...`, it means "match the remainder of the line only";
+//! if a line ends with `...`, it means "match the start of the line only". A line may start and
+//! end with `...`. `stderr`/`stdout` matches ignore leading/trailing whitespace and newlines, but
+//! are case sensitive.
 
 mod fuzzy;
 mod parser;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -119,31 +119,31 @@ fn key_multiline_val<'a>(
     let (key, first_line_val) = key_val(lines, line_off, indent);
     line_off += 1;
     let mut val = vec![first_line_val];
-    let sub_indent = indent_level(lines, line_off);
-    while line_off < lines.len() {
-        let cur_indent = indent_level(lines, line_off);
-        if cur_indent == lines[line_off].len() {
-            val.push("");
+    if line_off < lines.len() {
+        let sub_indent = indent_level(lines, line_off);
+        while line_off < lines.len() {
+            let cur_indent = indent_level(lines, line_off);
+            if cur_indent == lines[line_off].len() {
+                val.push("");
+                line_off += 1;
+                continue;
+            }
+            if cur_indent <= indent {
+                break;
+            }
+            val.push(&lines[line_off][sub_indent..].trim());
             line_off += 1;
-            continue;
-        }
-        if cur_indent <= indent {
-            break;
-        }
-        val.push(&lines[line_off][sub_indent..].trim());
-        line_off += 1;
-    }
-    while !val.is_empty() {
-        if !val[val.len() - 1].is_empty() {
-            break;
-        }
-        val.pop().unwrap();
-    }
-    while !val.is_empty() {
-        if val[0].is_empty() {
-            val.remove(0);
         }
     }
+    // Remove trailing empty strings
+    val.drain(
+        val.iter()
+            .rposition(|x| !x.is_empty())
+            .map(|x| x + 1)
+            .unwrap_or(val.len())..,
+    );
+    // Remove leading empty strings
+    val.drain(0..val.iter().position(|x| !x.is_empty()).unwrap_or(0));
     if val.is_empty() {
         panic!("Key without value at line {}", orig_line_off);
     }

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -185,7 +185,7 @@ impl<'a> LangTester<'a> {
                 read_to_string(p.as_path()).expect(&format!("Couldn't read {}", test_name));
             let test_str = self.test_extract.as_ref().unwrap()(&all_str)
                 .expect(&format!("Couldn't extract test string from {}", test_name));
-            if test_str.trim().is_empty() {
+            if test_str.is_empty() {
                 write_with_colour("ignored", Color::Yellow);
                 eprint!(" (test string is empty)");
                 num_ignored += 1;


### PR DESCRIPTION
After breaking the fuzzy matcher out into its own file (it's stand alone, so doing so helps make `tester.rs` feel a little less intimidating), this fixes a bug in the current fuzzy matcher (https://github.com/softdevteam/lang_tester/commit/c9317f508e6ad0c50bfb553060f663fdd960312f) and then allows `...` to be used at the start and/or end of the line (https://github.com/softdevteam/lang_tester/commit/65d39d86b249b5fbb43dfb1d8f51549275c64076). This doesn't hugely affect code complexity, but does make it easier to think about from an end-user's perspective IMHO>