### PR TITLE
Parallel tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ path = "examples/rust_lang_tester/run_tests.rs"
 
 [dependencies]
 getopts = "0.2"
+num_cpus = "1.10"
 termcolor = "1.0"
+threadpool = "1.7"
 walkdir = "2"
 
 [dev-dependencies]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -11,7 +11,7 @@ const WILDCARD: &str = "...";
 
 /// Does `s` conform to the fuzzy pattern `pattern`? Note that `plines` is expected not to start or
 /// end with blank lines, and each line is expected to be `trim`ed.
-pub(crate) fn match_vec(plines: &[&str], s: &str) -> bool {
+pub(crate) fn match_vec(plines: &Vec<String>, s: &str) -> bool {
     let slines = s.trim().lines().map(|x| x.trim()).collect::<Vec<_>>();
 
     let mut pi = 0;
@@ -26,10 +26,10 @@ pub(crate) fn match_vec(plines: &[&str], s: &str) -> bool {
             if plines[pi] == WILDCARD {
                 panic!("Can't have '{}' on two consecutive lines.", WILDCARD);
             }
-            while si < slines.len() && !match_line(plines[pi], slines[si]) {
+            while si < slines.len() && !match_line(&plines[pi], slines[si]) {
                 si += 1;
             }
-        } else if match_line(plines[pi], slines[si]) {
+        } else if match_line(&plines[pi], slines[si]) {
             pi += 1;
             si += 1;
         } else {
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn test_match_vec() {
         fn match_vec_helper(p: &str, s: &str) -> bool {
-            match_vec(&p.lines().collect::<Vec<_>>(), s)
+            match_vec(&p.lines().map(|x| x.to_owned()).collect::<Vec<_>>(), s)
         }
         assert!(match_vec_helper("", ""));
         assert!(match_vec_helper("a", "a"));

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -11,7 +11,7 @@ const WILDCARD: &str = "...";
 
 /// Does `s` conform to the fuzzy pattern `pattern`? Note that `plines` is expected not to start or
 /// end with blank lines, and each line is expected to be `trim`ed.
-pub(crate) fn match_vec(plines: &Vec<String>, s: &str) -> bool {
+pub(crate) fn match_vec(plines: &[&str], s: &str) -> bool {
     let slines = s.trim().lines().map(|x| x.trim()).collect::<Vec<_>>();
 
     let mut pi = 0;
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn test_match_vec() {
         fn match_vec_helper(p: &str, s: &str) -> bool {
-            match_vec(&p.lines().map(|x| x.to_owned()).collect::<Vec<_>>(), s)
+            match_vec(&p.lines().collect::<Vec<_>>(), s)
         }
         assert!(match_vec_helper("", ""));
         assert!(match_vec_helper("a", "a"));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,12 +69,10 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, Test> {
                             test.status = Some(status);
                         }
                         "stderr" => {
-                            test.stderr =
-                                Some(val.iter().map(|x| x.to_string()).collect::<Vec<_>>());
+                            test.stderr = Some(val);
                         }
                         "stdout" => {
-                            test.stdout =
-                                Some(val.iter().map(|x| x.to_string()).collect::<Vec<_>>());
+                            test.stdout = Some(val);
                         }
                         _ => panic!("Unknown key '{}' on line {}.", key, line_off),
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use crate::tester::{Status, Test};
 
 /// Parse test input into a set of `Test`s.
-pub(crate) fn parse_tests<'a>(test_str: &'a str) -> HashMap<String, Test<'a>> {
+pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, Test> {
     let lines = test_str.lines().collect::<Vec<_>>();
     let mut tests = HashMap::new();
     let mut line_off = 0;
@@ -69,10 +69,12 @@ pub(crate) fn parse_tests<'a>(test_str: &'a str) -> HashMap<String, Test<'a>> {
                             test.status = Some(status);
                         }
                         "stderr" => {
-                            test.stderr = Some(val);
+                            test.stderr =
+                                Some(val.iter().map(|x| x.to_string()).collect::<Vec<_>>());
                         }
                         "stdout" => {
-                            test.stdout = Some(val);
+                            test.stdout =
+                                Some(val.iter().map(|x| x.to_string()).collect::<Vec<_>>());
                         }
                         _ => panic!("Unknown key '{}' on line {}.", key, line_off),
                     }


### PR DESCRIPTION
This makes `lang_tester` run tests in parallel (one job per CPU core). This seriously speeds things up -- yksom's tiny test suite of 6 language tests by over 2x on my 2 core laptop with hyper-threading on (and a mere ~1.8x with hyper-threading off).

https://github.com/softdevteam/lang_tester/commit/9cc27f7abbeab154d09af9b911bb701944cbf828 does the parallelisation in a simple but effective way. https://github.com/softdevteam/lang_tester/commit/da955eef58bb34de2399f764f73434551a1dded6 and https://github.com/softdevteam/lang_tester/commit/2e1dbe66dd3661f3b5fbdae72237cceb44031d8e are semi-mechanical commits which prepare the ground for doing "full and proper" parallisation in https://github.com/softdevteam/lang_tester/commit/6159172091ea9c0d97d9cac97ec3b65da73ed72e.