### PR TITLE
Exit the process on a fatal error.

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -7,6 +7,8 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+use crate::fatal;
+
 const WILDCARD: &str = "...";
 
 /// Does `s` conform to the fuzzy pattern `pattern`? Note that `plines` is expected not to start or
@@ -24,7 +26,10 @@ pub(crate) fn match_vec(plines: &[&str], s: &str) -> bool {
                 return true;
             }
             if plines[pi] == WILDCARD {
-                panic!("Can't have '{}' on two consecutive lines.", WILDCARD);
+                fatal(&format!(
+                    "Can't have '{}' on two consecutive lines.",
+                    WILDCARD
+                ));
             }
             while si < slines.len() && !match_line(&plines[pi], slines[si]) {
                 si += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,3 +160,8 @@ mod parser;
 mod tester;
 
 pub use tester::LangTester;
+
+pub(crate) fn fatal(msg: &str) -> ! {
+    eprintln!("\nFatal exception:\n  {}", msg);
+    std::process::exit(1);
+}


### PR DESCRIPTION
The problem with running things multi-threaded is that a panic in one thread doesn't kill the others, so the user can easily end up not noticing that something very bad has happened. This commit turns panics into process-exiting fatal errors: when something bad happens, it's now very hard not to notice it!