### PR TITLE
Bail out as soon as a test has failed.

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -483,8 +483,13 @@ fn run_tests(
                     if pass_stdout.is_none() || pass_stdout == Some(false) {
                         failure.stdout = Some(stdout_utf8);
                     }
+
+                    // If a sub-test failed, bail out immediately, otherwise subsequent sub-tests
+                    // will overwrite the failure output!
+                    break;
                 }
 
+                // If a command failed, and we weren't expecting it to, bail out immediately.
                 if !output.status.success() && meant_to_error {
                     break;
                 }


### PR DESCRIPTION
If we have several tests:

```
  A:
    stdout: ...

  B:
    stdout: ...
```

then if test A failed, we want to stop immediately, otherwise test B might still succeed and lead to confusion. In other words, stop on the first error, and print the output of that error to the user.

Most of this PR is a couple of comments to clarify the situation, but the newly added `break` is critical!