### PR TITLE
Warn users when a test has exceeded a timeout.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ getopts = "0.2"
 num_cpus = "1.10"
 termcolor = "1.0"
 threadpool = "1.7"
+wait-timeout = "0.2"
 walkdir = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
This commit prints a warning to stderr every multiple of `TIMEOUT` seconds that a given test has not completed. This is subtly different to cargo, which only prints a warning after `TIMEOUT` has been exceeded once (if something's very slow, for debugging reasons it can sometimes be nice to know *how* slow).

This is particularly useful when running parallel tests when it is often not obvious why the test runner has not completed. This is similar to how `cargo test` works.