### PR TITLE
Really delete blank lines.

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -14,6 +14,8 @@ const WILDCARD: &str = "...";
 /// Does `s` conform to the fuzzy pattern `pattern`? Note that `plines` is expected not to start or
 /// end with blank lines, and each line is expected to be `trim`ed.
 pub(crate) fn match_vec(plines: &[&str], s: &str) -> bool {
+    debug_assert!(plines.is_empty() || !plines[0].is_empty());
+    debug_assert!(plines.is_empty() || !plines[plines.len() - 1].is_empty());
     let slines = s.trim().lines().map(|x| x.trim()).collect::<Vec<_>>();
 
     let mut pi = 0;


### PR DESCRIPTION
We stated this as an invariant for fuzzy::match_vec but the code that should have enforced it didn't work properly. Mea culpa!

As well as fixing this (with, perhaps inevitably, simpler code than the buggy code it replaces!), this commit adds asserts to stop this ever happening again.