### PR TITLE
Add ability to pass per test command line args

### DIFF
--- a/examples/rust_lang_tester/lang_tests/custom_cla.rs
+++ b/examples/rust_lang_tester/lang_tests/custom_cla.rs
@@ -1,0 +1,21 @@
+// Run-time:
+//   extra-args: 1
+//   extra-args: 2
+//   status: success
+
+use std::env;
+
+fn main() {
+    let arg1 = env::args()
+        .nth(1)
+        .expect("no arg 1 passed")
+        .parse::<i32>()
+        .expect("arg 1 should be numeric");
+
+    let arg2 = env::args()
+        .nth(2)
+        .expect("no arg 2 passed")
+        .parse::<i32>()
+        .expect("arg 2 should be numeric");
+    assert!( arg1 < arg2)
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,6 +40,7 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
             Entry::Vacant(e) => {
                 line_off += 1;
                 let mut testcmd = TestCmd {
+                    args: Vec::new(),
                     status: None,
                     stderr: None,
                     stdout: None,
@@ -56,6 +57,10 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
                     let (end_line_off, key, val) = key_multiline_val(&lines, line_off, sub_indent);
                     line_off = end_line_off;
                     match key {
+                        "extra-args" => {
+                            let val_str = val.join("\n");
+                            testcmd.args.push(val_str);
+                        }
                         "status" => {
                             let val_str = val.join("\n");
                             let status = match val_str.to_lowercase().as_str() {


### PR DESCRIPTION
Sometimes it's desirable to run certain tests (or subcommands) with custom command line arguments. This commit adds the ability to do this without the need for defining a separate test harness.

We introduce a new keyword, `args`, which can be optionally specified for each test command. For example, suppose an individual test relied on handling some user input, one could pass this input as follows:

```
Run-time:
    args: 1234
    status: success
```

This passes the command line argument 1234 to the command named "Run-time". Note that command line arguments are always passed as strings.

It is important to remember that custom arguments should not break invariants which are relied upon by the test runner. For example, suppose a test runner has two commands: compile, and then execute a C program. If an individual test provides a custom argument to specify a different output for the compiled binary:

```
Compile:
    args: -o /tmp/
    ...
```

Then the test harness will fail, as it will not know to look in the optionally specified /tmp/ directory.