### PR TITLE
Explicitly use defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,12 @@ Users can then write test files such as the following:
 
 ```rust
 // Compiler:
-//   status: success
 //   stderr:
 //     warning: unused variable: `x`
 //       ...unused_var.rs:12:9
 //       ...
 //
 // Run-time:
-//   status: success
 //   stdout: Hello world
 fn main() {
     let x = 0;
@@ -89,7 +87,8 @@ define at least one sub-test:
   * `status: <success|failure|<int>>`, where `success` and `failure` map to
     platform specific notions of a command completing successfully or
     unsuccessfully respectively and `<int>` is a signed integer checking for a
-    specific exit code on platforms that support it.
+    specific exit code on platforms that support it. If not specified,
+    defaults to `success`.
   * `stderr: [<string>]`, `stdout: [<string>]` are matched strings against a
     command's `stderr` or `stdout`. The special string `...` can be used as a
     simple wildcard: if a line consists solely of `...`, it means "match zero
@@ -97,7 +96,10 @@ define at least one sub-test:
     of the line only"; if a line ends with `...`, it means "match the start of
     the line only". A line may start and end with `...`. Note that
     `stderr`/`stdout` matches ignore leading/trailing whitespace and newlines,
-    but are case sensitive.
+    but are case sensitive. If not specified, defaults to `...` (i.e. match
+    anything). Note that the empty string matches only the empty string so
+    e.g. `stderr:` on its own means that a command's `stderr` muct not contain
+    any output.
 
 Test commands can alter the general command by specifying zero or more of the
 following:
@@ -106,15 +108,11 @@ following:
     will be appended, in order, to those arguments specified as part of
     the `test_cmds` function.
 
-The above file thus contains 4 actual tests: the `Compiler` should succeed
-(e.g. return a `0` exit code when run on Unix), and its `stderr` output should
-warn about an unused variable on line 12; and the resulting binary should
-succeed and produce `Hello world` on `stdout`.
-
-Potential sub-tests that are not mentioned are not tested: for example, the
-above file does not state whether the `Compiler`s `stdout` should have content
-or not (but note that the line `stdout:` on its own would state that the
-`Compiler` should have no content at all).
+The above file thus contains 4 meaningful tests, two specified by the user and
+two implied by defaults: the `Compiler` should succeed (e.g.  return a `0` exit
+code when run on Unix), and its `stderr` output should warn about an unused
+variable on line 12; and the resulting binary should succeed produce `Hello
+world` on `stdout`.
 
 `lang_tester`'s output is deliberately similar to Rust's normal testing output.
 Running the example `rust_lang_tester` in this crate produces the following

--- a/examples/rust_lang_tester/lang_tests/custom_cla.rs
+++ b/examples/rust_lang_tester/lang_tests/custom_cla.rs
@@ -1,7 +1,6 @@
 // Run-time:
 //   extra-args: 1
 //   extra-args: 2
-//   status: success
 
 use std::env;
 

--- a/examples/rust_lang_tester/lang_tests/unused_var.rs
+++ b/examples/rust_lang_tester/lang_tests/unused_var.rs
@@ -1,12 +1,10 @@
 // Compiler:
-//   status: success
 //   stderr:
 //     warning: unused variable: `x`
-//       ...unused_var.rs:12:9
+//       ...unused_var.rs:10:9
 //       ...
 //
 // Run-time:
-//   status: success
 //   stdout: Hello world
 fn main() {
     let x = 0;

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -76,6 +76,9 @@ mod tests {
         assert!(match_vec_helper("", ""));
         assert!(match_vec_helper("a", "a"));
         assert!(!match_vec_helper("a", "ab"));
+        assert!(match_vec_helper("...", ""));
+        assert!(match_vec_helper("...", "a"));
+        assert!(match_vec_helper("...", "a\nb"));
         assert!(match_vec_helper("...\na", "a"));
         assert!(match_vec_helper("...\na\n...", "a"));
         assert!(match_vec_helper("a\n...", "a"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,23 +91,28 @@
 //! command must define at least one sub-test:
 //!
 //!   * `status: <success|failure|<int>>`, where `success` and `failure` map to platform specific
-//!      notions of a command completing successfully or unsuccessfully respectively and `<int>` is a
-//!      signed integer checking for a specific exit code on platforms that support it.
+//!     notions of a command completing successfully or unsuccessfully respectively and `<int>` is
+//!     a signed integer checking for a specific exit code on platforms that support it. If not
+//!     specified, defaults to `success`.
 //!   * `stderr: [<string>]`, `stdout: [<string>]` are matched strings against a command's `stderr`
 //!     or `stdout`. The special string `...` can be used as a simple wildcard: if a line consists
 //!     solely of `...`, it means "match zero or more lines"; if a line begins with `...`, it means
 //!     "match the remainder of the line only"; if a line ends with `...`, it means "match the
 //!     start of the line only". A line may start and end with `...`. Note that `stderr`/`stdout`
-//!     matches ignore leading/trailing whitespace and newlines, but are case sensitive.
+//!     matches ignore leading/trailing whitespace and newlines, but are case sensitive. If not
+//!     specified, defaults to `...` (i.e. match anything). Note that the empty string matches only
+//!     the empty string so e.g. `stderr:` on its own means that a command's `stderr` muct not
+//!     contain any output.
 //!
 //! Test commands can alter the general command by specifying zero or more of the following:
 //!
 //!   * `extra-args: <arg 1> [... <arg n>]`, where each space separated argument will be appended,
 //!     in order, to those arguments specified as part of the `test_cmds` function.
 //!
-//! Potential sub-tests that are not mentioned are not tested: for example, the above file does not
-//! state whether the `Compiler`s `stdout` should have content or not (but note that the line
-//! `stdout:` on its own would state that the `Compiler` should have no content at all).
+//! The above file thus contains 4 meaningful tests, two specified by the user and two implied by
+//! defaults: the `Compiler` should succeed (e.g.  return a `0` exit code when run on Unix), and
+//! its `stderr` output should warn about an unused variable on line 12; and the resulting binary
+//! should succeed produce `Hello world` on `stdout`.
 //!
 //! `lang_tester`'s output is deliberately similar to Rust's normal testing output. Running the
 //! example `rust_lang_tester` in this crate produces the following output:

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,12 +39,7 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
             )),
             Entry::Vacant(e) => {
                 line_off += 1;
-                let mut testcmd = TestCmd {
-                    args: Vec::new(),
-                    status: None,
-                    stderr: None,
-                    stdout: None,
-                };
+                let mut testcmd = TestCmd::default();
                 while line_off < lines.len() {
                     let sub_indent = indent_level(&lines, line_off);
                     if sub_indent == lines[line_off].len() {
@@ -77,13 +72,13 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
                                     }
                                 }
                             };
-                            testcmd.status = Some(status);
+                            testcmd.status = status;
                         }
                         "stderr" => {
-                            testcmd.stderr = Some(val);
+                            testcmd.stderr = val;
                         }
                         "stdout" => {
-                            testcmd.stdout = Some(val);
+                            testcmd.stdout = val;
                         }
                         _ => fatal(&format!("Unknown key '{}' on line {}.", key, line_off)),
                     }


### PR DESCRIPTION
This PR embraces the new era of lang_tester using defaults to simplify the code base. The motivation is contained in the doc changes of https://github.com/softdevteam/lang_tester/commit/e13d06647235906f28e92a05dce8c2acf674fa3b, with the code then being easily simplified (in a way that's semantically backwards compatible, though note that it does change the output shown to users when tests fail) in https://github.com/softdevteam/lang_tester/commit/dc4e11c14926dffdc790afa5253d5a26d417791a. This PR deletes more code than it adds! Please test, though, on your own code to check that it doesn't do anything silly!