### PR TITLE
Add support for --nocapture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "rust_lang_tester"
 path = "examples/rust_lang_tester/run_tests.rs"
 
 [dependencies]
+filedescriptor = "0.5"
 getopts = "0.2"
 num_cpus = "1.10"
 termcolor = "1.0"

--- a/examples/rust_lang_tester/lang_tests/unused_var.rs
+++ b/examples/rust_lang_tester/lang_tests/unused_var.rs
@@ -1,11 +1,12 @@
 // Compiler:
 //   stderr:
 //     warning: unused variable: `x`
-//       ...unused_var.rs:10:9
+//       ...unused_var.rs:11:9
 //       ...
 //
 // Run-time:
 //   stdout: Hello world
+
 fn main() {
     let x = 0;
     println!("Hello world");


### PR DESCRIPTION
This adds support for `--nocapture` to lang_tester. The main part of the PR is https://github.com/softdevteam/lang_tester/commit/d0ac369a66d84c3f246c1e7c8d0706456a1b1023. As with normal `cargo test`, `--nocapture` on its own tends to lead to baffling interleaving of commands: it generally pairs well with `--test-threads=1`.