### PR TITLE
Remmove quotes from output.

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -325,7 +325,7 @@ impl<'a> LangTester<'a> {
                 }
                 if let Some(ref stdout) = test.stdout {
                     eprintln!(
-                        "\n---- lang_tests::{} stdout ----\n'{}'\n",
+                        "\n---- lang_tests::{} stdout ----\n{}\n",
                         test_fname, stdout
                     );
                 }


### PR DESCRIPTION
The extra `'` characters had crept in during testing and I didn't notice them when making a previous PR. Mea culpa!