### PR TITLE
Add status for specifying that a signal was caught

### DIFF
--- a/examples/rust_lang_tester/lang_tests/sig_caught.rs
+++ b/examples/rust_lang_tester/lang_tests/sig_caught.rs
@@ -1,0 +1,11 @@
+// Run-time:
+//   status: signal
+
+use std::process;
+
+fn main() {
+    unsafe {
+        let ptr = std::ptr::null::<usize>();
+        *ptr + 1;
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -61,6 +61,7 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
                             let status = match val_str.to_lowercase().as_str() {
                                 "success" => Status::Success,
                                 "error" => Status::Error,
+                                "signal" => Status::Signal,
                                 x => {
                                     if let Ok(i) = x.parse::<i32>() {
                                         Status::Int(i)

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -354,7 +354,7 @@ impl<'a> LangTester<'a> {
 }
 
 /// The status of an executed command.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Status {
     /// The command exited successfully (by whatever definition of "successful" the running
     /// platform uses).
@@ -408,6 +408,24 @@ fn write_with_colour(s: &str, colour: Color) {
     stderr.reset().ok();
 }
 
+fn write_ignored(test_name: &str, message: &str, inner: Arc<LangTesterPooler>) {
+    // Grab a lock on stderr so that we can avoid the possibility of lines blurring
+    // together in confusing ways.
+    let stderr = StandardStream::stderr(ColorChoice::Always);
+    let mut handle = stderr.lock();
+    if inner.test_threads > 1 {
+        handle
+            .write_all(&format!("\ntest lang_tests::{} ... ", test_name).as_bytes())
+            .ok();
+    }
+    handle
+        .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))
+        .ok();
+    handle.write_all(b"ignored").ok();
+    handle.reset().ok();
+    handle.write_all(format!(" ({})", message).as_bytes()).ok();
+}
+
 fn usage() -> ! {
     eprintln!("Usage: [--test-threads=<n>] <filter1> [... <filtern>]");
     process::exit(1);
@@ -453,27 +471,30 @@ fn run_tests(
             let test_str = inner.test_extract.as_ref().unwrap()(&all_str).unwrap_or_else(|| {
                 fatal(&format!("Couldn't extract test string from {}", test_fname))
             });
+
             if test_str.is_empty() {
-                // Grab a lock on stderr so that we can avoid the possibility of lines blurring
-                // together in confusing ways.
-                let stderr = StandardStream::stderr(ColorChoice::Always);
-                let mut handle = stderr.lock();
-                if inner.test_threads > 1 {
-                    handle
-                        .write_all(&format!("\ntest lang_tests::{} ... ", test_fname).as_bytes())
-                        .ok();
-                }
-                handle
-                    .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))
-                    .ok();
-                handle.write_all(b"ignored").ok();
-                handle.reset().ok();
-                handle.write_all(b" (test string is empty)").ok();
+                write_ignored(test_fname.as_str(), "test string is empty", inner);
                 num_ignored += 1;
                 return;
             }
 
             let tests = parse_tests(&test_str);
+
+            if !cfg!(unix)
+                && tests
+                    .values()
+                    .find(|t| t.status == Status::Signal)
+                    .is_some()
+            {
+                write_ignored(
+                    test_fname.as_str(),
+                    "signal termination not supported on this platform",
+                    inner,
+                );
+                num_ignored += 1;
+                return;
+            }
+
             let cmd_pairs = inner.test_cmds.as_ref().unwrap()(p.as_path())
                 .into_iter()
                 .map(|(test_name, cmd)| (test_name.to_lowercase(), cmd))
@@ -529,13 +550,7 @@ fn run_tests(
                                 }
                             }
                             Status::Signal => {
-                                if cfg!(unix) {
-                                    failure.status = Some("Did not exit due to signal".to_owned());
-                                } else {
-                                    failure.status = Some(
-                                        "Use of signal not supported on this platform".to_owned(),
-                                    )
-                                }
+                                failure.status = Some("Exit was not due to signal".to_owned());
                             }
                             Status::Int(_) => {
                                 failure.status = Some(


### PR DESCRIPTION
If the user expects a command, `x`, to terminate due to a signal being
thrown, they can now specify this explicitly, rather than using the
generic "error" status.

A test will still pass if it expects an "error" status from `x` which
terminated with a signal, as "error" is a superset of "signal".