### PR TITLE
Ignorable tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ define at least one sub-test:
     on Unix platforms; on non-Unix platforms, the test will be ignored. `<int>`
     is a signed integer checking for a specific exit code on platforms that
     support it. If not specified, defaults to `success`.
-  * `stderr: [<string>]`, `stdout: [<string>]` are matched strings against a
+  * `stderr: [<string>]`, `stdout: [<string>]` match `<string>` against a
     command's `stderr` or `stdout`. The special string `...` can be used as a
     simple wildcard: if a line consists solely of `...`, it means "match zero
     or more lines"; if a line begins with `...`, it means "match the remainder

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ code when run on Unix), and its `stderr` output should warn about an unused
 variable on line 12; and the resulting binary should succeed produce `Hello
 world` on `stdout`.
 
+A file's tests can be ignored entirely if a test command `ignore` is defined:
+
+  * `ignore: [<string>]`, specifies that this file should be ignored for the
+    reason set out in `<string>` (if any). When the test is run, `<string>`
+    will be printed out to inform users of the reason why the test is ignored.
+
 `lang_tester`'s output is deliberately similar to Rust's normal testing output.
 Running the example `rust_lang_tester` in this crate produces the following
 output:

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ world` on `stdout`.
 A file's tests can be ignored entirely if a test command `ignore` is defined:
 
   * `ignore: [<string>]`, specifies that this file should be ignored for the
-    reason set out in `<string>` (if any). When the test is run, `<string>`
-    will be printed out to inform users of the reason why the test is ignored.
+    reason set out in `<string>` (if any).  Note that `<string>` is purely for
+    user information and has no effect on the running of tests.
 
 `lang_tester`'s output is deliberately similar to Rust's normal testing output.
 Running the example `rust_lang_tester` in this crate produces the following

--- a/examples/rust_lang_tester/lang_tests/ignore.rs
+++ b/examples/rust_lang_tester/lang_tests/ignore.rs
@@ -1,0 +1,7 @@
+// ignore: this test is intentionally ignored
+// Compiler:
+//   status: success
+
+fn main() {
+    panic!("Shouldn't happen.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //!     `signal` checks for termination due to a signal on Unix platforms; on non-Unix platforms, the
 //!     test will be ignored. `<int>` is a signed integer checking for a specific exit code on platforms
 //!     that support it. If not specified, defaults to `success`.
-//!   * `stderr: [<string>]`, `stdout: [<string>]` are matched strings against a command's `stderr`
+//!   * `stderr: [<string>]`, `stdout: [<string>]` match `<string>` against a command's `stderr`
 //!     or `stdout`. The special string `...` can be used as a simple wildcard: if a line consists
 //!     solely of `...`, it means "match zero or more lines"; if a line begins with `...`, it means
 //!     "match the remainder of the line only"; if a line ends with `...`, it means "match the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@
 //! A file's tests can be ignored entirely if a test command `ignore` is defined:
 //!
 //!   * `ignore: [<string>]`, specifies that this file should be ignored for the reason set out in
-//!     `<string>` (if any). When the test is run, `<string>` will be printed out to inform users
-//!     of the reason why the test is ignored.
+//!     `<string>` (if any). Note that `<string>` is purely for user information and has no effect
+//!     on the running of tests.
 //!
 //! `lang_tester`'s output is deliberately similar to Rust's normal testing output. Running the
 //! example `rust_lang_tester` in this crate produces the following output:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,12 @@
 //! its `stderr` output should warn about an unused variable on line 12; and the resulting binary
 //! should succeed produce `Hello world` on `stdout`.
 //!
+//! A file's tests can be ignored entirely if a test command `ignore` is defined:
+//!
+//!   * `ignore: [<string>]`, specifies that this file should be ignored for the reason set out in
+//!     `<string>` (if any). When the test is run, `<string>` will be printed out to inform users
+//!     of the reason why the test is ignored.
+//!
 //! `lang_tester`'s output is deliberately similar to Rust's normal testing output. Running the
 //! example `rust_lang_tester` in this crate produces the following output:
 //!

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,6 +10,7 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
     let lines = test_str.lines().collect::<Vec<_>>();
     let mut tests = HashMap::new();
     let mut line_off = 0;
+    let mut ignore = false;
     while line_off < lines.len() {
         let indent = indent_level(&lines, line_off);
         if indent == lines[line_off].len() {
@@ -18,7 +19,9 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
         }
         let (test_name, val) = key_val(&lines, line_off, indent);
         if test_name == "ignore" {
-            return Tests::Ignore(val.to_owned());
+            ignore = true;
+            line_off += 1;
+            continue;
         }
         if !val.is_empty() {
             fatal(&format!(
@@ -82,7 +85,7 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
             }
         }
     }
-    Tests::Tests(tests)
+    Tests { ignore, tests }
 }
 
 fn indent_level(lines: &[&str], line_off: usize) -> usize {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,11 +2,11 @@ use std::collections::hash_map::{Entry, HashMap};
 
 use crate::{
     fatal,
-    tester::{Status, TestCmd},
+    tester::{Status, TestCmd, Tests},
 };
 
 /// Parse test data into a set of `Test`s.
-pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
+pub(crate) fn parse_tests(test_str: &str) -> Tests {
     let lines = test_str.lines().collect::<Vec<_>>();
     let mut tests = HashMap::new();
     let mut line_off = 0;
@@ -17,6 +17,9 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
             continue;
         }
         let (test_name, val) = key_val(&lines, line_off, indent);
+        if test_name == "ignore" {
+            return Tests::Ignore(val.to_owned());
+        }
         if !val.is_empty() {
             fatal(&format!(
                 "Test name '{}' can't have a value on line {}.",
@@ -79,7 +82,7 @@ pub(crate) fn parse_tests(test_str: &str) -> HashMap<String, TestCmd> {
             }
         }
     }
-    tests
+    Tests::Tests(tests)
 }
 
 fn indent_level(lines: &[&str], line_off: usize) -> usize {

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -46,6 +46,7 @@ pub struct LangTester<'a> {
 /// `Arc`.
 struct LangTesterPooler {
     test_threads: usize,
+    ignored: bool,
     nocapture: bool,
     test_extract: Option<Box<dyn Fn(&str) -> Option<String> + Send + Sync>>,
     test_cmds: Option<Box<dyn Fn(&Path) -> Vec<(&str, Command)> + Send + Sync>>,
@@ -62,6 +63,7 @@ impl<'a> LangTester<'a> {
             use_cmdline_args: true,
             cmdline_filters: None,
             inner: Arc::new(LangTesterPooler {
+                ignored: false,
                 nocapture: false,
                 test_threads: num_cpus::get(),
                 test_extract: None,
@@ -253,6 +255,7 @@ impl<'a> LangTester<'a> {
             let args: Vec<String> = env::args().collect();
             let matches = Options::new()
                 .optflag("h", "help", "")
+                .optflag("", "ignored", "Run only ignored tests")
                 .optflag(
                     "",
                     "nocapture",
@@ -268,6 +271,9 @@ impl<'a> LangTester<'a> {
                 .unwrap_or_else(|_| usage());
             if matches.opt_present("h") {
                 usage();
+            }
+            if matches.opt_present("ignored") {
+                Arc::get_mut(&mut self.inner).unwrap().ignored = true;
             }
             if matches.opt_present("nocapture") {
                 Arc::get_mut(&mut self.inner).unwrap().nocapture = true;
@@ -286,7 +292,7 @@ impl<'a> LangTester<'a> {
         let (test_files, num_filtered) = self.test_files();
         eprint!("\nrunning {} tests", test_files.len());
         let test_files_len = test_files.len();
-        let (failures, num_ignored) = run_tests(test_files, Arc::clone(&self.inner));
+        let (failures, num_ignored) = test_file(test_files, Arc::clone(&self.inner));
 
         self.pp_failures(&failures, test_files_len, num_ignored, num_filtered);
 
@@ -384,9 +390,9 @@ impl<'a> TestCmd<'a> {
 }
 
 /// A collection of tests.
-pub(crate) enum Tests<'a> {
-    Ignore(String),
-    Tests(HashMap<String, TestCmd<'a>>),
+pub(crate) struct Tests<'a> {
+    pub ignore: bool,
+    pub tests: HashMap<String, TestCmd<'a>>,
 }
 
 /// If one or more parts of a `TestCmd` fail, the parts that fail are set to `Some(...)` in an
@@ -420,11 +426,13 @@ fn write_ignored(test_name: &str, message: &str, inner: Arc<LangTesterPooler>) {
         .ok();
     handle.write_all(b"ignored").ok();
     handle.reset().ok();
-    handle.write_all(format!(" ({})", message).as_bytes()).ok();
+    if !message.is_empty() {
+        handle.write_all(format!(" ({})", message).as_bytes()).ok();
+    }
 }
 
 fn usage() -> ! {
-    eprintln!("Usage: [--test-threads=<n>] <filter1> [... <filtern>]");
+    eprintln!("Usage: [--ignored] [--nocapture] [--test-threads=<n>] [<filter1>] [... <filtern>]");
     process::exit(1);
 }
 
@@ -447,7 +455,7 @@ fn check_names<'a>(cmd_pairs: &[(String, Command)], tests: &HashMap<String, Test
 }
 
 /// Run every test in `test_files`, returning a tuple `(failures, num_ignored)`.
-fn run_tests(
+fn test_file(
     test_files: Vec<PathBuf>,
     inner: Arc<LangTesterPooler>,
 ) -> (Vec<(String, TestFailure)>, usize) {
@@ -475,152 +483,15 @@ fn run_tests(
                 return;
             }
 
-            match parse_tests(&test_str) {
-                Tests::Ignore(s) => write_ignored(test_fname.as_str(), &s, inner),
-                Tests::Tests(tests) => {
-                    if !cfg!(unix)
-                        && tests
-                            .values()
-                            .find(|t| t.status == Status::Signal)
-                            .is_some()
-                    {
-                        write_ignored(
-                            test_fname.as_str(),
-                            "signal termination not supported on this platform",
-                            inner,
-                        );
-                        num_ignored += 1;
-                        return;
-                    }
+            let tests = parse_tests(&test_str);
+            if (inner.ignored && !tests.ignore) || (!inner.ignored && tests.ignore) {
+                write_ignored(test_fname.as_str(), "", inner);
+                num_ignored += 1;
+                return;
+            }
 
-                    let cmd_pairs = inner.test_cmds.as_ref().unwrap()(p.as_path())
-                        .into_iter()
-                        .map(|(test_name, cmd)| (test_name.to_lowercase(), cmd))
-                        .collect::<Vec<_>>();
-                    check_names(&cmd_pairs, &tests);
-
-                    let mut failure = TestFailure {
-                        status: None,
-                        stderr: None,
-                        stdout: None,
-                    };
-                    for (cmd_name, mut cmd) in cmd_pairs {
-                        let default_test = TestCmd::default();
-                        let test = tests.get(&cmd_name).unwrap_or(&default_test);
-                        cmd.args(&test.args);
-                        let (status, stderr, stdout) = run_cmd(inner.clone(), &test_fname, cmd);
-
-                        let mut meant_to_error = false;
-
-                        // First, check whether the tests passed.
-                        let pass_status = match test.status {
-                            Status::Success => status.success(),
-                            Status::Error => {
-                                meant_to_error = true;
-                                !status.success()
-                            }
-                            Status::Signal => status.signal().is_some(),
-                            Status::Int(i) => status.code() == Some(i),
-                        };
-                        let pass_stderr = fuzzy::match_vec(&test.stderr, &stderr);
-                        let pass_stdout = fuzzy::match_vec(&test.stdout, &stdout);
-
-                        // Second, if a test failed, we want to print out everything which didn't match
-                        // successfully (i.e. if the stderr test failed, print that out; but, equally, if
-                        // stderr wasn't specified as a test, print it out, because the user can't
-                        // otherwise know what it contains).
-                        if !(pass_status && pass_stderr && pass_stdout) {
-                            if !pass_status || failure.status.is_none() {
-                                match test.status {
-                                    Status::Success | Status::Error => {
-                                        if status.success() {
-                                            failure.status = Some("Success".to_owned());
-                                        } else if status.code().is_none() {
-                                            failure.status = Some(
-                                                format!(
-                                                    "Exited due to signal: {}",
-                                                    status.signal().unwrap()
-                                                )
-                                                .to_owned(),
-                                            );
-                                        } else {
-                                            failure.status = Some("Error".to_owned());
-                                        }
-                                    }
-                                    Status::Signal => {
-                                        failure.status =
-                                            Some("Exit was not due to signal".to_owned());
-                                    }
-                                    Status::Int(_) => {
-                                        failure.status = Some(
-                                            status.code().map(|x| x.to_string()).unwrap_or_else(
-                                                || {
-                                                    format!(
-                                                        "Exited due to signal: {}",
-                                                        status.signal().unwrap()
-                                                    )
-                                                    .to_owned()
-                                                },
-                                            ),
-                                        )
-                                    }
-                                }
-                            }
-
-                            if !pass_stderr || failure.stderr.is_none() {
-                                failure.stderr = Some(stderr);
-                            }
-
-                            if !pass_stdout || failure.stdout.is_none() {
-                                failure.stdout = Some(stdout);
-                            }
-
-                            // If a sub-test failed, bail out immediately, otherwise subsequent sub-tests
-                            // will overwrite the failure output!
-                            break;
-                        }
-
-                        // If a command failed, and we weren't expecting it to, bail out immediately.
-                        if !status.success() && meant_to_error {
-                            break;
-                        }
-                    }
-
-                    {
-                        // Grab a lock on stderr so that we can avoid the possibility of lines blurring
-                        // together in confusing ways.
-                        let stderr = StandardStream::stderr(ColorChoice::Always);
-                        let mut handle = stderr.lock();
-                        if inner.test_threads > 1 {
-                            handle
-                                .write_all(
-                                    &format!("\ntest lang_tests::{} ... ", test_fname).as_bytes(),
-                                )
-                                .ok();
-                        }
-                        if failure
-                            != (TestFailure {
-                                status: None,
-                                stderr: None,
-                                stdout: None,
-                            })
-                        {
-                            let mut failures = failures.lock().unwrap();
-                            failures.push((test_fname, failure));
-                            handle
-                                .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
-                                .ok();
-                            handle.write_all(b"FAILED").ok();
-                            handle.reset().ok();
-                        } else {
-                            handle
-                                .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
-                                .ok();
-                            handle.write_all(b"ok").ok();
-                            handle.reset().ok();
-                        }
-                    }
-                }
+            if run_tests(Arc::clone(&inner), tests.tests, p, failures) {
+                num_ignored += 1;
             }
         });
     }
@@ -628,6 +499,148 @@ fn run_tests(
     let failures = Mutex::into_inner(Arc::try_unwrap(failures).unwrap()).unwrap();
 
     (failures, num_ignored)
+}
+
+/// Run the tests for `path`.
+fn run_tests<'a>(
+    inner: Arc<LangTesterPooler>,
+    tests: HashMap<String, TestCmd<'a>>,
+    path: PathBuf,
+    failures: Arc<Mutex<Vec<(String, TestFailure)>>>,
+) -> bool {
+    let test_fname = path.file_stem().unwrap().to_str().unwrap().to_owned();
+
+    if !cfg!(unix)
+        && tests
+            .values()
+            .find(|t| t.status == Status::Signal)
+            .is_some()
+    {
+        write_ignored(
+            test_fname.as_str(),
+            "signal termination not supported on this platform",
+            inner,
+        );
+        return true;
+    }
+
+    let cmd_pairs = inner.test_cmds.as_ref().unwrap()(path.as_path())
+        .into_iter()
+        .map(|(test_name, cmd)| (test_name.to_lowercase(), cmd))
+        .collect::<Vec<_>>();
+    check_names(&cmd_pairs, &tests);
+
+    let mut failure = TestFailure {
+        status: None,
+        stderr: None,
+        stdout: None,
+    };
+    for (cmd_name, mut cmd) in cmd_pairs {
+        let default_test = TestCmd::default();
+        let test = tests.get(&cmd_name).unwrap_or(&default_test);
+        cmd.args(&test.args);
+        let (status, stderr, stdout) = run_cmd(inner.clone(), &test_fname, cmd);
+
+        let mut meant_to_error = false;
+
+        // First, check whether the tests passed.
+        let pass_status = match test.status {
+            Status::Success => status.success(),
+            Status::Error => {
+                meant_to_error = true;
+                !status.success()
+            }
+            Status::Signal => status.signal().is_some(),
+            Status::Int(i) => status.code() == Some(i),
+        };
+        let pass_stderr = fuzzy::match_vec(&test.stderr, &stderr);
+        let pass_stdout = fuzzy::match_vec(&test.stdout, &stdout);
+
+        // Second, if a test failed, we want to print out everything which didn't match
+        // successfully (i.e. if the stderr test failed, print that out; but, equally, if
+        // stderr wasn't specified as a test, print it out, because the user can't
+        // otherwise know what it contains).
+        if !(pass_status && pass_stderr && pass_stdout) {
+            if !pass_status || failure.status.is_none() {
+                match test.status {
+                    Status::Success | Status::Error => {
+                        if status.success() {
+                            failure.status = Some("Success".to_owned());
+                        } else if status.code().is_none() {
+                            failure.status = Some(
+                                format!("Exited due to signal: {}", status.signal().unwrap())
+                                    .to_owned(),
+                            );
+                        } else {
+                            failure.status = Some("Error".to_owned());
+                        }
+                    }
+                    Status::Signal => {
+                        failure.status = Some("Exit was not due to signal".to_owned());
+                    }
+                    Status::Int(_) => {
+                        failure.status =
+                            Some(status.code().map(|x| x.to_string()).unwrap_or_else(|| {
+                                format!("Exited due to signal: {}", status.signal().unwrap())
+                                    .to_owned()
+                            }))
+                    }
+                }
+            }
+
+            if !pass_stderr || failure.stderr.is_none() {
+                failure.stderr = Some(stderr);
+            }
+
+            if !pass_stdout || failure.stdout.is_none() {
+                failure.stdout = Some(stdout);
+            }
+
+            // If a sub-test failed, bail out immediately, otherwise subsequent sub-tests
+            // will overwrite the failure output!
+            break;
+        }
+
+        // If a command failed, and we weren't expecting it to, bail out immediately.
+        if !status.success() && meant_to_error {
+            break;
+        }
+    }
+
+    {
+        // Grab a lock on stderr so that we can avoid the possibility of lines blurring
+        // together in confusing ways.
+        let stderr = StandardStream::stderr(ColorChoice::Always);
+        let mut handle = stderr.lock();
+        if inner.test_threads > 1 {
+            handle
+                .write_all(&format!("\ntest lang_tests::{} ... ", test_fname).as_bytes())
+                .ok();
+        }
+        if failure
+            != (TestFailure {
+                status: None,
+                stderr: None,
+                stdout: None,
+            })
+        {
+            let mut failures = failures.lock().unwrap();
+            failures.push((test_fname, failure));
+            handle
+                .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                .ok();
+            handle.write_all(b"FAILED").ok();
+            handle.reset().ok();
+        } else {
+            handle
+                .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
+                .ok();
+            handle.write_all(b"ok").ok();
+            handle.reset().ok();
+        }
+    }
+
+    false
 }
 
 fn run_cmd(


### PR DESCRIPTION
Sometimes we might want to add tests that we can't yet run successfully, so being able to ignore them can be useful.