### PR TITLE
Implement non-blocking.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "examples/rust_lang_tester/run_tests.rs"
 [dependencies]
 filedescriptor = "0.5"
 getopts = "0.2"
+nix = "0.16.0"
 num_cpus = "1.10"
 termcolor = "1.0"
 threadpool = "1.7"


### PR DESCRIPTION
Implement non-blocking for file descriptors. This works with `filedescriptor` using its `poll(2)` implementation but doesn't work with it using its `select(2)` implementation. However, I want to be utterly sure that I have implemented non-blocking properly before I try other things like implementing our own `select(2)` solution.