### PR TITLE
Add function to specify number of test threads

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -85,6 +85,14 @@ impl<'a> LangTester<'a> {
         self
     }
 
+    /// Specify the number of simultaneous running test cases. Defaults to using
+    /// all available CPUs.
+    pub fn test_threads(&'a mut self, test_threads: usize) -> &'a mut Self {
+        let inner = Arc::get_mut(&mut self.inner).unwrap();
+        inner.test_threads = test_threads;
+        self
+    }
+
     /// If `test_file_filter` is specified, only files for which it returns `true` will be
     /// considered tests. A common use of this is to filter files based on filename extensions
     /// e.g.:


### PR DESCRIPTION
This function allows the user to specify the default number of test threads ahead of time. This is useful if, for example, a test harness will only work in a single threaded context, since lang_tester attempts to parallelise by default.

It's a draft PR for now as I want to check if you're happy with the API. If so I'll add some docs for it and update it.