### PR TITLE
Print out the name of nested tests in a more pleasing way

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -12,6 +12,7 @@ export PATH=`pwd`/.cargo/bin/:$PATH
 
 cargo fmt --all -- --check
 cargo test
+cargo run --example rust_lang_tester
 
 which cargo-deny | cargo install cargo-deny
 cargo-deny check license

--- a/examples/rust_lang_tester/lang_tests/nested/test.rs
+++ b/examples/rust_lang_tester/lang_tests/nested/test.rs
@@ -1,0 +1,10 @@
+// Compiler:
+//   status: success
+//
+// Run-time:
+//   status: success
+//   stdout: nested test
+
+fn main() {
+    println!("nested test");
+}

--- a/examples/rust_lang_tester/lang_tests/no_main.rs
+++ b/examples/rust_lang_tester/lang_tests/no_main.rs
@@ -3,8 +3,6 @@
 //   stderr:
 //     error[E0601]: `main` function not found in crate `no_main`
 //     ...
-//     ...consider adding a `main` function to `examples/rust_lang_tester/lang_tests/no_main.rs`
-//
 //     error: aborting due to previous error
 //
 //     For more information about this error, try `rustc --explain E0601`.


### PR DESCRIPTION
Although I'd never tried it, lang_tester supported nested tests (i.e. tests in nested directories). However, if you had something like:

```
  lang_tests/
    a.rs
    b/
      c.rs
```

then the output would be:

```
  lang_tests::a.rs
  lang_tests::c.rs
```

That seems OK until you do this:

```
  lang_tests/
    a.rs
    b/
      a.rs
```

and then the output would be:

```
  lang_tests::a.rs
  lang_tests::a.rs
```

Which test is which?

This commit makes it so that nested tests print out their directory name(s):

```
  lang_tests::a.rs
  lang_tests::b::a.rs
```

This does rely on path canonicalisation, which is never entirely guaranteed to succeed, so there is a fallback mechanism if it fails.