### PR TITLE
Add the ability to override fm's defaults when using lang_tester.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -12,6 +12,7 @@ export PATH=`pwd`/.cargo/bin/:$PATH
 
 cargo fmt --all -- --check
 cargo test
+cargo run --example fm_options
 cargo run --example rust_lang_tester
 
 which cargo-deny | cargo install cargo-deny

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2018"
 name = "rust_lang_tester"
 path = "examples/rust_lang_tester/run_tests.rs"
 
+[[example]]
+name = "fm_options"
+path = "examples/fm_options/run_tests.rs"
+
 [dependencies]
 fm = "0.1"
 getopts = "0.2"
@@ -24,4 +28,5 @@ wait-timeout = "0.2"
 walkdir = "2"
 
 [dev-dependencies]
+regex = "1.3.9"
 tempfile = "3"

--- a/examples/fm_options/lang_tests/nondeterministic.py
+++ b/examples/fm_options/lang_tests/nondeterministic.py
@@ -1,0 +1,16 @@
+# VM:
+#   status: success
+#   stdout:
+#     $1
+#     b
+#     $1
+
+import random
+
+ALPHABET = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+            "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
+
+x = random.choice(ALPHABET)
+print(x)
+print("b")
+print(x)

--- a/examples/fm_options/lang_tests/simple.py
+++ b/examples/fm_options/lang_tests/simple.py
@@ -1,0 +1,10 @@
+# VM:
+#   status: success
+#   stdout:
+#     $1
+#     b
+#     $1
+
+print("a")
+print("b")
+print("a")

--- a/examples/fm_options/run_tests.rs
+++ b/examples/fm_options/run_tests.rs
@@ -1,0 +1,36 @@
+//! This is an example lang_tester that shows how to set options using the `fm` fuzzy matcher
+//! library, using Python files as an example.
+
+use std::process::Command;
+
+use lang_tester::LangTester;
+use regex::Regex;
+
+fn main() {
+    LangTester::new()
+        .test_dir("examples/fm_options/lang_tests")
+        .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "py")
+        .test_extract(|s| {
+            Some(
+                s.lines()
+                    // Skip non-commented lines at the start of the file.
+                    .skip_while(|l| !l.starts_with("#"))
+                    // Extract consecutive commented lines.
+                    .take_while(|l| l.starts_with("#"))
+                    .map(|l| &l[2..])
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        })
+        .fm_options(|_, _, fmb| {
+            let ptn_re = Regex::new(r"\$.+?\b").unwrap();
+            let text_re = Regex::new(r".+?\b").unwrap();
+            fmb.name_matcher(Some((ptn_re, text_re)))
+        })
+        .test_cmds(move |p| {
+            let mut vm = Command::new("python3");
+            vm.args(&[p.to_str().unwrap()]);
+            vec![("VM", vm)]
+        })
+        .run();
+}


### PR DESCRIPTION
This allows lang_tester users to e.g. use name matching in their tests.

I'm not sure if this is the right API or not: it's flexible but that brings some complexity as well. We could, for example, pass a boolean `is_stderr`, but that would restrict us forever more to just stderr/stdout tests. Maybe that's all we need, but I'm not sure.