### PR TITLE
Don't strip leading whitespace from lines.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "fm_options"
 path = "examples/fm_options/run_tests.rs"
 
 [dependencies]
-fm = "0.1"
+fm = "0.1.1"
 getopts = "0.2"
 libc = "0.2"
 num_cpus = "1.10"

--- a/README.md
+++ b/README.md
@@ -81,8 +81,21 @@ fn main() {
 Test data is specified with a two-level indentation syntax: the outer most
 level of indentation defines a test command (multiple command names can be
 specified, as in the above); the inner most level of indentation defines
-alterations to the general command or sub-tests. Each test command must
-define at least one sub-test:
+alterations to the general command or sub-tests. Multi-line values are stripped
+of their common indentation, such that:
+
+```text
+x:
+  a
+    b
+  c
+```
+
+defines a test command `x` with a value `a\n  b\nc`. Trailing whitespace is
+not stripped from each line. Note that by default `fm` ignores leading and
+trailing whitespace.
+
+Each test command must define at least one sub-test:
 
   * `status: <success|failure|signal|<int>>`, where `success` and `failure` map
     to platform specific notions of a command completing successfully or

--- a/examples/fm_options/lang_tests/echo.py
+++ b/examples/fm_options/lang_tests/echo.py
@@ -1,0 +1,15 @@
+# VM:
+#   status: success
+#   stdin:
+#     a
+#       b
+#     a
+#   stdout:
+#     $1
+#       b
+#     $1
+
+import sys
+
+for l in sys.stdin:
+    sys.stdout.write(l)

--- a/examples/fm_options/run_tests.rs
+++ b/examples/fm_options/run_tests.rs
@@ -26,6 +26,7 @@ fn main() {
             let ptn_re = Regex::new(r"\$.+?\b").unwrap();
             let text_re = Regex::new(r".+?\b").unwrap();
             fmb.name_matcher(Some((ptn_re, text_re)))
+                .ignore_leading_whitespace(false)
         })
         .test_cmds(move |p| {
             let mut vm = Command::new("python3");

--- a/examples/rust_lang_tester/lang_tests/echo_multiline.rs
+++ b/examples/rust_lang_tester/lang_tests/echo_multiline.rs
@@ -1,0 +1,18 @@
+// Run-time:
+//   status: success
+//   stdin:
+//     a
+//     b
+//     c
+//   stdout:
+//     Hello a
+//     b
+//     c
+
+use std::io::{Read, stdin};
+
+fn main() {
+    let mut buf = String::new();
+    stdin().read_to_string(&mut buf).unwrap();
+    println!("Hello {}", buf);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,20 @@
 //!
 //! Test data is specified with a two-level indentation syntax: the outer most level of indentation
 //! defines a test command (multiple command names can be specified, as in the above); the inner
-//! most level of indentation defines alterations to the general command or sub-tests. Each test
-//! command must define at least one sub-test:
+//! most level of indentation defines alterations to the general command or sub-tests. Multi-line
+//! values are stripped of their common indentation, such that:
+//!
+//! ```text
+//! x:
+//!   a
+//!     b
+//!   c
+//! ```
+//!
+//! defines a key `x` with a value `a\n  b\nc`. Trailing whitespace is not stripped from each line.
+//! Note that by default `fm` ignores leading and trailing whitespace.
+//!
+//! Each test command must define at least one sub-test:
 //!
 //!   * `status: <success|failure|signal|<int>>`, where `success` and `failure` map to platform
 //!     specific notions of a command completing successfully or unsuccessfully respectively.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -122,11 +122,11 @@ fn key_val<'a>(lines: &[&'a str], line_off: usize, indent: usize) -> (&'a str, &
         .chars()
         .take_while(|c| c.is_whitespace())
         .count();
-    (key, &line[content_start..].trim())
+    (key, &line[content_start..])
 }
 
 /// Turn one more lines of the format `key: val` (where `val` may spread over many lines) into its
-/// separate components. Guarantees to trim leading and trailing newlines.
+/// separate components.
 fn key_multiline_val<'a>(
     lines: &[&'a str],
     mut line_off: usize,
@@ -147,7 +147,7 @@ fn key_multiline_val<'a>(
             if cur_indent <= indent {
                 break;
             }
-            val.push(&lines[line_off][sub_indent..].trim());
+            val.push(&lines[line_off][sub_indent..]);
             line_off += 1;
         }
     }
@@ -180,7 +180,11 @@ mod test {
         );
         assert_eq!(
             key_multiline_val(&["x:", "  z  ", "  a  ", "  ", "b"], 0, 0),
-            (4, "x", vec!["z", "a"])
+            (4, "x", vec!["z  ", "a  "])
+        );
+        assert_eq!(
+            key_multiline_val(&["x:", "  z  ", "    a  ", "  ", "  b"], 0, 0),
+            (5, "x", vec!["z  ", "  a  ", "", "b"])
         );
     }
 }


### PR DESCRIPTION
This allows us to write things such as:

```
  x:
    a
      b
    c
```

and differentiate the leading whitespace in the lines. Trailing whitespace is always stripped. Note that this change is backwards compatible because `fm` defaults to whitespace-insensitive matching, so unless users explicitly request whitespace-sensitive matching they won't know the difference.

This fixes https://github.com/softdevteam/lang_tester/issues/65 in a simpler way than I think we originally thought possible.