### PR TITLE
Display errors as fm output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "fm_options"
 path = "examples/fm_options/run_tests.rs"
 
 [dependencies]
-fm = "0.1.1"
+fm = "0.1.2"
 getopts = "0.2"
 libc = "0.2"
 num_cpus = "1.10"


### PR DESCRIPTION
If an fm match fails, this commit uses the output from fm rather than printing
the raw stdout/stderr. For example, with the upcoming context support in fm,
this leads to the helpful output such as the following:

```
  ---- lang_tests::nested_backtrace2.som stderr ----

  Pattern (error at line 3):
     |Traceback (most recent call at bottom):
     |  ...
  >> |  ...nested_backtrace2.som, line 30, column 12:
     |      run = ( self m )
     |  ...nested_backtrace2.som, line 26, column 8:
     |          1 == 0
     ...

  Text (error at line 28):
     ...
     |          self ifFalse: [ ^falseBlock value ].
     |  File /home/ltratt/yksom/lang_tests/nested_backtrace2.som, line 29, column 21:
     |            ifFalse: [ 2 / 0 ].
  >> |Division by zero.
```

This makes it much easier to understand why a test failed. Previously I had
sometimes spent ridiculous periods of time trying to work out why a test pattern
had not matched: I think this will cut that down significantly.