### PR TITLE
Prepare a 0.4.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# lang_tester 0.4.0 (2020-11-26)
+
+* Update to fm 0.2.0. This changes the interface exposed by the `fm_options`
+  function. See the [`fm`
+  changes](https://github.com/softdevteam/fm/blob/master/CHANGES.md) for more
+  information.
+
+
 # lang_tester 0.3.13 (2020-11-09)
 
 * Silence some Clippy warnings and fix documentation inconsistencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lang_tester"
 description = "Concise language testing framework for compilers and VMs"
 repository = "https://github.com/softdevteam/lang_tester/"
-version = "0.3.13"
+version = "0.4.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
Since we expose `fm` directly to the user, the bump in its interface requires us to bump `lang_tester`'s version to 0.4.0.