### PR TITLE
Make test_extract take `&Path`s rather than `&str`s.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,31 @@
+# lang_tester 0.5.0 (xxxx-xx-xx)
+
+* The `test_extract` function signature has changed from:
+  ```
+  Fn(&str) -> Option<String> + Send + Sync,
+  ```
+  to:
+  ```
+  Fn(&Path) -> String + Send + Sync,
+  ```
+
+  In other words, users now have to both:
+
+    1. Read the contents of a path themselves (but it doesn't necessarily have
+       to be the path passed to the function!)
+    2. Return a `String` rather than an `Option<String>`.
+
+  In practise, most `test_extract` functions can be changed from (roughly):
+  ```
+  test_extract(|s| { s.lines() ... })
+  ```
+  to:
+  ```
+  test_extract(|p| { read_to_string(p).lines() })
+  ```
+
+
+
 # lang_tester 0.4.0 (2020-11-26)
 
 * Update to fm 0.2.0. This changes the interface exposed by the `fm_options`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, a Rust language tester, loosely in the spirit of
 [`compiletest_rs`](https://crates.io/crates/compiletest_rs), looks as follows:
 
 ```rust
-use std::{path::PathBuf, process::Command};
+use std::{fs::read_to_string, path::PathBuf, process::Command};
 
 use lang_tester::LangTester;
 use tempfile::TempDir;
@@ -26,17 +26,17 @@ fn main() {
         // Only use files named `*.rs` as test files.
         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
         // Extract the first sequence of commented line(s) as the tests.
-        .test_extract(|s| {
-            Some(
-                s.lines()
+        .test_extract(|p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
                     // Skip non-commented lines at the start of the file.
                     .skip_while(|l| !l.starts_with("//"))
                     // Extract consecutive commented lines.
                     .take_while(|l| l.starts_with("//"))
                     .map(|l| &l[2..])
                     .collect::<Vec<_>>()
-                    .join("\n"),
-            )
+                    .join("\n")
         })
         // We have two test commands:
         //   * `Compiler`: runs rustc.

--- a/examples/fm_options/run_tests.rs
+++ b/examples/fm_options/run_tests.rs
@@ -1,7 +1,7 @@
 //! This is an example lang_tester that shows how to set options using the `fm` fuzzy matcher
 //! library, using Python files as an example.
 
-use std::process::Command;
+use std::{fs::read_to_string, process::Command};
 
 use lang_tester::LangTester;
 use regex::Regex;
@@ -10,17 +10,17 @@ fn main() {
     LangTester::new()
         .test_dir("examples/fm_options/lang_tests")
         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "py")
-        .test_extract(|s| {
-            Some(
-                s.lines()
-                    // Skip non-commented lines at the start of the file.
-                    .skip_while(|l| !l.starts_with("#"))
-                    // Extract consecutive commented lines.
-                    .take_while(|l| l.starts_with("#"))
-                    .map(|l| &l[2..])
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-            )
+        .test_extract(|p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
+                // Skip non-commented lines at the start of the file.
+                .skip_while(|l| !l.starts_with("#"))
+                // Extract consecutive commented lines.
+                .take_while(|l| l.starts_with("#"))
+                .map(|l| &l[2..])
+                .collect::<Vec<_>>()
+                .join("\n")
         })
         .fm_options(|_, _, fmb| {
             let ptn_re = Regex::new(r"\$.+?\b").unwrap();

--- a/examples/rust_lang_tester/run_tests.rs
+++ b/examples/rust_lang_tester/run_tests.rs
@@ -4,7 +4,7 @@
 //!
 //! See the test files in `lang_tests/` for example.
 
-use std::{path::PathBuf, process::Command};
+use std::{fs::read_to_string, path::PathBuf, process::Command};
 
 use lang_tester::LangTester;
 use tempfile::TempDir;
@@ -18,17 +18,17 @@ fn main() {
         // Only use files named `*.rs` as test files.
         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
         // Extract the first sequence of commented line(s) as the tests.
-        .test_extract(|s| {
-            Some(
-                s.lines()
-                    // Skip non-commented lines at the start of the file.
-                    .skip_while(|l| !l.starts_with("//"))
-                    // Extract consecutive commented lines.
-                    .take_while(|l| l.starts_with("//"))
-                    .map(|l| &l[2..])
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-            )
+        .test_extract(|p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
+                // Skip non-commented lines at the start of the file.
+                .skip_while(|l| !l.starts_with("//"))
+                // Extract consecutive commented lines.
+                .take_while(|l| l.starts_with("//"))
+                .map(|l| &l[2..])
+                .collect::<Vec<_>>()
+                .join("\n")
         })
         // We have two test commands:
         //   * `Compiler`: runs rustc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`compiletest_rs`](https://crates.io/crates/compiletest_rs), looks as follows:
 //!
 //! ```rust
-//! use std::{path::PathBuf, process::Command};
+//! use std::{fs::read_to_string, path::PathBuf, process::Command};
 //!
 //! use lang_tester::LangTester;
 //! use tempfile::TempDir;
@@ -22,17 +22,17 @@
 //!         // Only use files named `*.rs` as test files.
 //!         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
 //!         // Extract the first sequence of commented line(s) as the tests.
-//!         .test_extract(|s| {
-//!             Some(
-//!                 s.lines()
-//!                     // Skip non-commented lines at the start of the file.
-//!                     .skip_while(|l| !l.starts_with("//"))
-//!                     // Extract consecutive commented lines.
-//!                     .take_while(|l| l.starts_with("//"))
-//!                     .map(|l| &l[2..])
-//!                     .collect::<Vec<_>>()
-//!                     .join("\n"),
-//!             )
+//!         .test_extract(|p| {
+//!             read_to_string(p)
+//!                 .unwrap()
+//!                 .lines()
+//!                 // Skip non-commented lines at the start of the file.
+//!                 .skip_while(|l| !l.starts_with("//"))
+//!                 // Extract consecutive commented lines.
+//!                 .take_while(|l| l.starts_with("//"))
+//!                 .map(|l| &l[2..])
+//!                 .collect::<Vec<_>>()
+//!                 .join("\n")
 //!         })
 //!         // We have two test commands:
 //!         //   * `Compiler`: runs rustc.


### PR DESCRIPTION
lang_tester tries to make it as easy as possible to set-up, so it has a fairly simple API. One way I did that was by passing the contents of a file to a `test_extract` function. However, that is fairly inflexible, and also it turns out not very much simpler (it doesn't help that `test_extract` returns `Option<String>`: frankly, it's easier for tests to panic in such situations).

This commit therefore changes the `test_extract` function signature from:

  ```
  Fn(&str) -> Option<String> + Send + Sync,
  ```

  to:

  ```
  Fn(&Path) -> String + Send + Sync,
  ```

In other words, users now have to a) read the contents of a path themselves (but
it doesn't necessarily have to be the path passed to the function!) b) return a
`String` rather than an `Option<String>`.

In practise, most `test_extract` functions can be changed from (roughly):

  ```
  test_extract(|s| { s.lines() ... })
  ```

to:

  ```
  test_extract(|p| { read_to_string(p).lines() })
  ```

Fixes https://github.com/softdevteam/lang_tester/issues/76 though at the expense of a relatively painful API bump. I think it's worth it though.