### PR TITLE
Try to get some of the concepts across more clearly in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ fn main() {
                     .skip_while(|l| !l.starts_with("//"))
                     // Extract consecutive commented lines.
                     .take_while(|l| l.starts_with("//"))
+                    // Strip the initial "//" from commented lines.
                     .map(|l| &l[2..])
                     .collect::<Vec<_>>()
                     .join("\n")

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ use std::{fs::read_to_string, path::PathBuf, process::Command};
 use lang_tester::LangTester;
 use tempfile::TempDir;
 
+static COMMENT_PREFIX: &str = "//";
+
 fn main() {
     // We use rustc to compile files into a binary: we store those binary files
     // into `tempdir`. This may not be necessary for other languages.
@@ -30,14 +32,13 @@ fn main() {
             read_to_string(p)
                 .unwrap()
                 .lines()
-                    // Skip non-commented lines at the start of the file.
-                    .skip_while(|l| !l.starts_with("//"))
-                    // Extract consecutive commented lines.
-                    .take_while(|l| l.starts_with("//"))
-                    // Strip the initial "//" from commented lines.
-                    .map(|l| &l[2..])
-                    .collect::<Vec<_>>()
-                    .join("\n")
+                // Skip non-commented lines at the start of the file.
+                .skip_while(|l| !l.starts_with(COMMENT_PREFIX))
+                // Extract consecutive commented lines.
+                .take_while(|l| l.starts_with(COMMENT_PREFIX))
+                .map(|l| &l[COMMENT_PREFIX.len()..])
+                .collect::<Vec<_>>()
+                .join("\n")
         })
         // We have two test commands:
         //   * `Compiler`: runs rustc.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This crate provides a simple language testing framework designed to help when
 you are testing things like compilers and virtual machines. It allows users to
-embed simple tests for process success/failure and for stderr/stdout inside a
-source file. It is loosely based on the
+express simple tests for process success/failure and for stderr/stdout, including
+embedding those tests directlly in the source file. It is loosely based on the
 [`compiletest_rs`](https://crates.io/crates/compiletest_rs) crate, but is much
 simpler (and hence sometimes less powerful), and designed to be used for
 testing non-Rust languages too.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ fn main() {
 }
 ```
 
+`lang_tester` is entirely ignorant of the language being tested, leaving it
+entirely to the user to determine what the test data in/for a file is. In this
+case, since we are embedding the test data as a Rust comment at the start of
+the file, the `test_extract` function we specified returns the following
+string:
+
+```
+Compiler:
+  stderr:
+    warning: unused variable: `x`
+      ...unused_var.rs:12:9
+      ...
+
+Run-time:
+  stdout: Hello world
+```
+
 Test data is specified with a two-level indentation syntax: the outer most
 level of indentation defines a test command (multiple command names can be
 specified, as in the above); the inner most level of indentation defines

--- a/examples/rust_lang_tester/run_tests.rs
+++ b/examples/rust_lang_tester/run_tests.rs
@@ -9,6 +9,8 @@ use std::{fs::read_to_string, path::PathBuf, process::Command};
 use lang_tester::LangTester;
 use tempfile::TempDir;
 
+static COMMENT_PREFIX: &str = "//";
+
 fn main() {
     // We use rustc to compile files into a binary: we store those binary files into `tempdir`.
     // This may not be necessary for other languages.
@@ -23,10 +25,10 @@ fn main() {
                 .unwrap()
                 .lines()
                 // Skip non-commented lines at the start of the file.
-                .skip_while(|l| !l.starts_with("//"))
+                .skip_while(|l| !l.starts_with(COMMENT_PREFIX))
                 // Extract consecutive commented lines.
-                .take_while(|l| l.starts_with("//"))
-                .map(|l| &l[2..])
+                .take_while(|l| l.starts_with(COMMENT_PREFIX))
+                .map(|l| &l[COMMENT_PREFIX.len()..])
                 .collect::<Vec<_>>()
                 .join("\n")
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! This crate provides a simple language testing framework designed to help when you are testing
-//! things like compilers and virtual machines. It allows users to embed simple tests for process
-//! success/failure and for stderr/stdout inside a source file. It is loosely based on the
-//! [`compiletest_rs`](https://crates.io/crates/compiletest_rs) crate, but is much simpler (and
-//! hence sometimes less powerful), and designed to be used for testing non-Rust languages too.
+//! things like compilers and virtual machines. It allows users to express simple tests for process
+//! success/failure and for stderr/stdout, including embedding those tests directlly in the source
+//! file. It is loosely based on the [`compiletest_rs`](https://crates.io/crates/compiletest_rs)
+//! crate, but is much simpler (and hence sometimes less powerful), and designed to be used for
+//! testing non-Rust languages too.
 //!
 //! For example, a Rust language tester, loosely in the spirit of
 //! [`compiletest_rs`](https://crates.io/crates/compiletest_rs), looks as follows:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //!                 .skip_while(|l| !l.starts_with("//"))
 //!                 // Extract consecutive commented lines.
 //!                 .take_while(|l| l.starts_with("//"))
+//!                 // Strip the initial "//" from commented lines.
 //!                 .map(|l| &l[2..])
 //!                 .collect::<Vec<_>>()
 //!                 .join("\n")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 //! use lang_tester::LangTester;
 //! use tempfile::TempDir;
 //!
+//! static COMMENT_PREFIX: &str = "//";
+//!
 //! fn main() {
 //!     // We use rustc to compile files into a binary: we store those binary files into `tempdir`.
 //!     // This may not be necessary for other languages.
@@ -28,11 +30,11 @@
 //!                 .unwrap()
 //!                 .lines()
 //!                 // Skip non-commented lines at the start of the file.
-//!                 .skip_while(|l| !l.starts_with("//"))
+//!                 .skip_while(|l| !l.starts_with(COMMENT_PREFIX))
 //!                 // Extract consecutive commented lines.
-//!                 .take_while(|l| l.starts_with("//"))
+//!                 .take_while(|l| l.starts_with(COMMENT_PREFIX))
 //!                 // Strip the initial "//" from commented lines.
-//!                 .map(|l| &l[2..])
+//!                 .map(|l| &l[COMMENT_PREFIX.len()..])
 //!                 .collect::<Vec<_>>()
 //!                 .join("\n")
 //!         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,22 @@
 //! }
 //! ```
 //!
+//! `lang_tester` is entirely ignorant of the language being tested, leaving it entirely to the
+//! user to determine what the test data in/for a file is. In this case, since we are embedding the
+//! test data as a Rust comment at the start of the file, the `test_extract` function we specified
+//! returns the following string:
+//!
+//! ```text
+//! Compiler:
+//!   stderr:
+//!     warning: unused variable: `x`
+//!       ...unused_var.rs:12:9
+//!       ...
+//!
+//! Run-time:
+//!   stdout: Hello world
+//! ```
+//!
 //! Test data is specified with a two-level indentation syntax: the outer most level of indentation
 //! defines a test command (multiple command names can be specified, as in the above); the inner
 //! most level of indentation defines alterations to the general command or sub-tests. Multi-line


### PR DESCRIPTION
This PR tries to clarify the documentation somewhat. The problem with `lang_tester` is that it's so brutally simple that there's a tendency to assume that it can't possibly be *that* simple. I've tried to bring out a few of the concepts more explicitly to emphasise the fundamentals a bit better. This will probably never be perfect, but anything which makes it better can only be a good thing.