### PR TITLE
Prepare a 0.6.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# lang_tester 0.6.1 (2021-04-30)
+
+* Fix test file filtering.
+
+
 # lang_tester 0.6.0 (2021-04-30)
 
 * If a function passed by the user to the user (e.g. to `test_extract`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lang_tester"
 description = "Concise language testing framework for compilers and VMs"
 repository = "https://github.com/softdevteam/lang_tester/"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -295,7 +295,7 @@ impl LangTester {
             // Filter out non-test files
             .filter(|x| match self.test_file_filter.as_ref() {
                 Some(f) => match catch_unwind(|| f(x)) {
-                    Ok(_) => true,
+                    Ok(b) => b,
                     Err(_) => {
                         let failure = TestFailure {
                             status: None,


### PR DESCRIPTION
0.6.0 had a nasty bug whereby file filtering didn't work. I've yanked that from crates.io but we should prepare a correct version ASAP.