### PR TITLE
Fix docs for, and rename, 'extra_arg'

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ Each test command must define at least one sub-test:
 Test commands can alter the general command by specifying zero or more of the
 following:
 
-  * `extra-args: <arg 1> [... <arg n>]`, where each space separated argument
-    will be appended, in order, to those arguments specified as part of
-    the `test_cmds` function.
+  * `extra-args: <string>` specifies a string which will be passed as an
+    additional command-line argument to the command (in addition to those
+    specified by the `test_cmds` function). Multiple `extra-args` can be
+    specified, each adding an additional command-line argument.
  * `stdin: <string>`, text to be passed to the command's `stdin`. If the
    command exits without having consumed all of `<string>`, an error will be
    raised. Note, though, that operating system file buffers can mean that the

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Each test command must define at least one sub-test:
 Test commands can alter the general command by specifying zero or more of the
 following:
 
-  * `extra-args: <string>` specifies a string which will be passed as an
+  * `extra-arg: <string>` specifies a string which will be passed as an
     additional command-line argument to the command (in addition to those
-    specified by the `test_cmds` function). Multiple `extra-args` can be
+    specified by the `test_cmds` function). Multiple `extra-arg`s can be
     specified, each adding an additional command-line argument.
  * `stdin: <string>`, text to be passed to the command's `stdin`. If the
    command exits without having consumed all of `<string>`, an error will be

--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ following:
     additional command-line argument to the command (in addition to those
     specified by the `test_cmds` function). Multiple `extra-arg`s can be
     specified, each adding an additional command-line argument.
- * `stdin: <string>`, text to be passed to the command's `stdin`. If the
-   command exits without having consumed all of `<string>`, an error will be
-   raised. Note, though, that operating system file buffers can mean that the
-   command *appears* to have consumed all of `<string>` without it actually
-   having done so.
+  * `stdin: <string>`, text to be passed to the command's `stdin`. If the
+    command exits without having consumed all of `<string>`, an error will be
+    raised. Note, though, that operating system file buffers can mean that the
+    command *appears* to have consumed all of `<string>` without it actually
+    having done so.
 
 The above file thus contains 4 meaningful tests, two specified by the user and
 two implied by defaults: the `Compiler` should succeed (e.g.  return a `0` exit

--- a/examples/rust_lang_tester/lang_tests/custom_cla.rs
+++ b/examples/rust_lang_tester/lang_tests/custom_cla.rs
@@ -1,6 +1,6 @@
 // Run-time:
-//   extra-args: 1
-//   extra-args: 2 3
+//   extra-arg: 1
+//   extra-arg: 2 3
 
 use std::env;
 

--- a/examples/rust_lang_tester/lang_tests/custom_cla.rs
+++ b/examples/rust_lang_tester/lang_tests/custom_cla.rs
@@ -1,10 +1,11 @@
 // Run-time:
 //   extra-args: 1
-//   extra-args: 2
+//   extra-args: 2 3
 
 use std::env;
 
 fn main() {
+    println!("{:?}", env::args());
     let arg1 = env::args()
         .nth(1)
         .expect("no arg 1 passed")
@@ -13,8 +14,6 @@ fn main() {
 
     let arg2 = env::args()
         .nth(2)
-        .expect("no arg 2 passed")
-        .parse::<i32>()
-        .expect("arg 2 should be numeric");
-    assert!( arg1 < arg2)
+        .unwrap();
+    assert_eq!(arg2, "2 3");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@
 //!     command-line argument to the command (in addition to those specified by the `test_cmds`
 //!     function). `extra-arg` can be specified multiple times, each adding an additional
 //!     command-line argument.
-//!   * stdin: <string>`, text to be passed to the command's `stdin`. If the command exits without
+//!   * `stdin: <string>`, text to be passed to the command's `stdin`. If the command exits without
 //!     having consumed all of `<string>`, an error will be raised. Note, though, that operating
 //!     system file buffers can mean that the command *appears* to have consumed all of `<string>`
 //!     without it actually having done so.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,11 @@
 //!
 //! Test commands can alter the general command by specifying zero or more of the following:
 //!
-//!   * `extra-args: <arg 1> [... <arg n>]`, where each space separated argument will be appended,
-//!     in order, to those arguments specified as part of the `test_cmds` function.
-//!   * `stdin: <string>`, text to be passed to the command's `stdin`. If the command exits without
+//!   * `extra-args: <string>` specifies a string which will be passed as an additional
+//!     command-line argument to the command (in addition to those specified by the `test_cmds`
+//!     function). Multiple `extra-args` can be specified, each adding an additional command-line
+//!     argument.
+//!   * stdin: <string>`, text to be passed to the command's `stdin`. If the command exits without
 //!     having consumed all of `<string>`, an error will be raised. Note, though, that operating
 //!     system file buffers can mean that the command *appears* to have consumed all of `<string>`
 //!     without it actually having done so.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,10 @@
 //!
 //! Test commands can alter the general command by specifying zero or more of the following:
 //!
-//!   * `extra-args: <string>` specifies a string which will be passed as an additional
+//!   * `extra-arg: <string>` specifies a string which will be passed as an additional
 //!     command-line argument to the command (in addition to those specified by the `test_cmds`
-//!     function). Multiple `extra-args` can be specified, each adding an additional command-line
-//!     argument.
+//!     function). `extra-arg` can be specified multiple times, each adding an additional
+//!     command-line argument.
 //!   * stdin: <string>`, text to be passed to the command's `stdin`. If the command exits without
 //!     having consumed all of `<string>`, an error will be raised. Note, though, that operating
 //!     system file buffers can mean that the command *appears* to have consumed all of `<string>`

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,7 +49,7 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
                     let (end_line_off, key, val) = key_multiline_val(&lines, line_off, sub_indent);
                     line_off = end_line_off;
                     match key {
-                        "extra-args" => {
+                        "extra-arg" => {
                             let val_str = val.join("\n");
                             testcmd.args.push(val_str);
                         }


### PR DESCRIPTION
The `extra-args` option is useful, but the documentation was misleading (https://github.com/softdevteam/lang_tester/commit/d014d43fb0f184746a37abb75af41b398e197fef) and indeed the very name of the key is misleading (https://github.com/softdevteam/lang_tester/commit/099096cb9936957be6d306d76593f9bf639775fa). The latter is a backwards incompatible change, but since I had to look at the source code to work out what's going on, it's hard to believe that many other people would be able to use this option correctly given it's currently-misleading name.