### PR TITLE
Add rerun-if-{status, stderr, stdout}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ path = "examples/rust_lang_tester/run_tests.rs"
 name = "fm_options"
 path = "examples/fm_options/run_tests.rs"
 
+[[test]]
+name = "lang_tests"
+path = "lang_tests/rerun/main.rs"
+harness = false
+
 [dependencies]
 fm = "0.2"
 getopts = "0.2"

--- a/lang_tests/rerun/lang_tests/rerun_status.py
+++ b/lang_tests/rerun/lang_tests/rerun_status.py
@@ -7,10 +7,9 @@ import os, sys
 cookie = os.path.join(os.environ["CARGO_TARGET_TMPDIR"], "rerun_status_cookie")
 i = 0
 if os.path.exists(cookie):
-    i = int(open(cookie, "r").read().strip())
+    i = int(open(cookie, "r").read().strip()) + 1
     if i == 5:
         sys.exit(0)
-    i += 1
 
 open(cookie, "w").write(str(i))
 sys.exit(42)

--- a/lang_tests/rerun/lang_tests/rerun_status.py
+++ b/lang_tests/rerun/lang_tests/rerun_status.py
@@ -1,0 +1,16 @@
+# VM:
+#   status: success
+#   rerun-if-status: 42
+
+import os, sys
+
+cookie = os.path.join(os.environ["CARGO_TARGET_TMPDIR"], "rerun_status_cookie")
+i = 0
+if os.path.exists(cookie):
+    i = int(open(cookie, "r").read().strip())
+    if i == 5:
+        sys.exit(0)
+    i += 1
+
+open(cookie, "w").write(str(i))
+sys.exit(42)

--- a/lang_tests/rerun/lang_tests/rerun_stderr.py
+++ b/lang_tests/rerun/lang_tests/rerun_stderr.py
@@ -8,11 +8,10 @@ import os, sys
 cookie = os.path.join(os.environ["CARGO_TARGET_TMPDIR"], "rerun_stderr_cookie")
 i = 0
 if os.path.exists(cookie):
-    i = int(open(cookie, "r").read().strip())
+    i = int(open(cookie, "r").read().strip()) + 1
     if i == 5:
         sys.stderr.write("a")
         sys.exit(0)
-    i += 1
 
 open(cookie, "w").write(str(i))
 sys.stderr.write("b")

--- a/lang_tests/rerun/lang_tests/rerun_stderr.py
+++ b/lang_tests/rerun/lang_tests/rerun_stderr.py
@@ -1,0 +1,18 @@
+# VM:
+#   status: success
+#   stderr: a
+#   rerun-if-stderr: b
+
+import os, sys
+
+cookie = os.path.join(os.environ["CARGO_TARGET_TMPDIR"], "rerun_stderr_cookie")
+i = 0
+if os.path.exists(cookie):
+    i = int(open(cookie, "r").read().strip())
+    if i == 5:
+        sys.stderr.write("a")
+        sys.exit(0)
+    i += 1
+
+open(cookie, "w").write(str(i))
+sys.stderr.write("b")

--- a/lang_tests/rerun/lang_tests/rerun_stdout.py
+++ b/lang_tests/rerun/lang_tests/rerun_stdout.py
@@ -1,0 +1,18 @@
+# VM:
+#   status: success
+#   stdout: a
+#   rerun-if-stdout: b
+
+import os, sys
+
+cookie = os.path.join(os.environ["CARGO_TARGET_TMPDIR"], "rerun_stdout_cookie")
+i = 0
+if os.path.exists(cookie):
+    i = int(open(cookie, "r").read().strip())
+    if i == 5:
+        sys.stdout.write("a")
+        sys.exit(0)
+    i += 1
+
+open(cookie, "w").write(str(i))
+sys.stdout.write("b")

--- a/lang_tests/rerun/lang_tests/rerun_stdout.py
+++ b/lang_tests/rerun/lang_tests/rerun_stdout.py
@@ -8,11 +8,10 @@ import os, sys
 cookie = os.path.join(os.environ["CARGO_TARGET_TMPDIR"], "rerun_stdout_cookie")
 i = 0
 if os.path.exists(cookie):
-    i = int(open(cookie, "r").read().strip())
+    i = int(open(cookie, "r").read().strip()) + 1
     if i == 5:
         sys.stdout.write("a")
         sys.exit(0)
-    i += 1
 
 open(cookie, "w").write(str(i))
 sys.stdout.write("b")

--- a/lang_tests/rerun/main.rs
+++ b/lang_tests/rerun/main.rs
@@ -1,0 +1,61 @@
+//! This is an example lang_tester that shows how to use the "rerun_if" commands.
+
+use std::{
+    env,
+    fs::{read_to_string, remove_file},
+    path::PathBuf,
+    process::Command,
+};
+
+/// In order that we can meaningfully have the same test behave differently from run to run, we
+/// have to leave cookies behind in target/tmp, which we must clear before starting a test run.
+/// This is horrible, but without doing something stateful, we can't test anything.
+const COOKIES: &[&str] = &[
+    "rerun_status_cookie",
+    "rerun_stderr_cookie",
+    "rerun_stdout_cookie",
+];
+
+use lang_tester::LangTester;
+use regex::Regex;
+
+fn main() {
+    env::set_var("CARGO_TARGET_TMPDIR", env!("CARGO_TARGET_TMPDIR"));
+
+    for cookie in COOKIES {
+        let mut p = PathBuf::new();
+        p.push(env::var("CARGO_TARGET_TMPDIR").unwrap());
+        p.push(cookie);
+        if p.exists() {
+            remove_file(p).unwrap();
+        }
+    }
+
+    LangTester::new()
+        .test_dir("lang_tests/rerun/")
+        .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "py")
+        .test_extract(|p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
+                // Skip non-commented lines at the start of the file.
+                .skip_while(|l| !l.starts_with("#"))
+                // Extract consecutive commented lines.
+                .take_while(|l| l.starts_with("#"))
+                .map(|l| &l[2..])
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .fm_options(|_, _, fmb| {
+            let ptn_re = Regex::new(r"\$.+?\b").unwrap();
+            let text_re = Regex::new(r".+?\b").unwrap();
+            fmb.name_matcher(ptn_re, text_re)
+                .ignore_leading_whitespace(false)
+        })
+        .test_cmds(move |p| {
+            let mut vm = Command::new("python3");
+            vm.args(&[p.to_str().unwrap()]);
+            vec![("VM", vm)]
+        })
+        .run();
+}

--- a/lang_tests/rerun/main.rs
+++ b/lang_tests/rerun/main.rs
@@ -32,6 +32,7 @@ fn main() {
     }
 
     LangTester::new()
+        .rerun_at_most(5)
         .test_dir("lang_tests/rerun/")
         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "py")
         .test_extract(|p| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,7 +69,7 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
                             let val_str = val.join("\n");
                             testcmd.args.push(val_str);
                         }
-                        "status" => {
+                        "status" | "rerun-if-status" => {
                             let val_str = val.join("\n");
                             let status = match val_str.to_lowercase().as_str() {
                                 "success" => Status::Success,
@@ -86,7 +86,17 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
                                     }
                                 }
                             };
-                            testcmd.status = status;
+                            match key {
+                                "status" => {
+                                    testcmd.status = status;
+                                }
+                                "rerun-if-status" => {
+                                    testcmd.rerun_if_status = Some(status);
+                                }
+                                _ => {
+                                    unreachable!();
+                                }
+                            }
                         }
                         "stdin" => {
                             testcmd.stdin = Some(val.join("\n"));
@@ -96,6 +106,12 @@ pub(crate) fn parse_tests(test_str: &str) -> Tests {
                         }
                         "stdout" => {
                             testcmd.stdout = val;
+                        }
+                        "rerun-if-stderr" => {
+                            testcmd.rerun_if_stderr = Some(val);
+                        }
+                        "rerun-if-stdout" => {
+                            testcmd.rerun_if_stdout = Some(val);
                         }
                         _ => fatal(&format!("Unknown key '{}' on line {}.", key, line_off)),
                     }

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -488,6 +488,9 @@ pub(crate) struct TestCmd<'a> {
     /// executing the test command.
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    pub rerun_if_status: Option<Status>,
+    pub rerun_if_stderr: Option<Vec<&'a str>>,
+    pub rerun_if_stdout: Option<Vec<&'a str>>,
 }
 
 impl<'a> TestCmd<'a> {
@@ -499,6 +502,9 @@ impl<'a> TestCmd<'a> {
             stdout: vec!["..."],
             args: Vec::new(),
             env: HashMap::new(),
+            rerun_if_status: None,
+            rerun_if_stderr: None,
+            rerun_if_stdout: None,
         }
     }
 }
@@ -683,71 +689,116 @@ fn run_tests(
     };
     check_names(&cmd_pairs, &tests);
 
-    for (cmd_name, mut cmd) in cmd_pairs {
+    'a: for (cmd_name, mut cmd) in cmd_pairs {
         let default_test = TestCmd::default();
         let test = tests.get(&cmd_name).unwrap_or(&default_test);
         cmd.args(&test.args);
         cmd.envs(&test.env);
-        let (status, stdin_remaining, stderr, stdout) =
-            run_cmd(inner.clone(), &test_fname, cmd, test);
+        loop {
+            let (status, stdin_remaining, stderr, stdout) =
+                run_cmd(inner.clone(), &test_fname, &mut cmd, test);
 
-        let mut meant_to_error = false;
+            let mut meant_to_error = false;
 
-        // Give the user the option of setting options for the fuzzy matchers.
-        let stderr_str = test.stderr.join("\n");
-        let mut stderr_fmb = FMBuilder::new(&stderr_str).unwrap();
-        let stdout_str = test.stdout.join("\n");
-        let mut stdout_fmb = FMBuilder::new(&stdout_str).unwrap();
-        if let Some(ref fm_options) = inner.fm_options {
-            match catch_unwind(|| {
-                (
-                    fm_options(path.as_path(), TestStream::Stderr, stderr_fmb),
-                    fm_options(path.as_path(), TestStream::Stdout, stdout_fmb),
-                )
-            }) {
-                Ok((x, y)) => {
-                    stderr_fmb = x;
-                    stdout_fmb = y;
+            // Give the user the option of setting options for the fuzzy matchers.
+            let stderr_str = test.stderr.join("\n");
+            let mut stderr_fmb = FMBuilder::new(&stderr_str).unwrap();
+            let stdout_str = test.stdout.join("\n");
+            let mut stdout_fmb = FMBuilder::new(&stdout_str).unwrap();
+
+            let rerun_if_stderr_str = test.rerun_if_stderr.as_ref().unwrap_or(&vec![]).join("\n");
+            let mut rerun_if_stderr_fmb = FMBuilder::new(&rerun_if_stderr_str).unwrap();
+            let rerun_if_stdout_str = test.rerun_if_stdout.as_ref().unwrap_or(&vec![]).join("\n");
+            let mut rerun_if_stdout_fmb = FMBuilder::new(&rerun_if_stdout_str).unwrap();
+            if let Some(ref fm_options) = inner.fm_options {
+                match catch_unwind(|| {
+                    (
+                        fm_options(path.as_path(), TestStream::Stderr, stderr_fmb),
+                        fm_options(path.as_path(), TestStream::Stdout, stdout_fmb),
+                        fm_options(path.as_path(), TestStream::Stderr, rerun_if_stderr_fmb),
+                        fm_options(path.as_path(), TestStream::Stdout, rerun_if_stdout_fmb),
+                    )
+                }) {
+                    Ok((a, b, c, d)) => {
+                        stderr_fmb = a;
+                        stdout_fmb = b;
+                        rerun_if_stderr_fmb = c;
+                        rerun_if_stdout_fmb = d;
+                    }
+                    Err(_) => {
+                        failures.lock().unwrap().push((test_fname, failure));
+                        return false;
+                    }
                 }
-                Err(_) => {
-                    failures.lock().unwrap().push((test_fname, failure));
-                    return false;
+            }
+
+            let match_stderr = match stderr_fmb.build() {
+                Ok(x) => x.matches(&stderr),
+                Err(e) => {
+                    failure.stderr = Some(format!("FM error: {}", e));
+                    break 'a;
                 }
-            }
-        }
+            };
+            let match_stdout = match stdout_fmb.build() {
+                Ok(x) => x.matches(&stdout),
+                Err(e) => {
+                    failure.stdout = Some(format!("FM error: {}", e));
+                    break 'a;
+                }
+            };
 
-        let match_stderr = match stderr_fmb.build() {
-            Ok(x) => x.matches(&stderr),
-            Err(e) => {
-                failure.stderr = Some(format!("FM error: {}", e));
-                break;
-            }
-        };
-        let match_stdout = match stdout_fmb.build() {
-            Ok(x) => x.matches(&stdout),
-            Err(e) => {
-                failure.stdout = Some(format!("FM error: {}", e));
-                break;
-            }
-        };
+            // First, check whether the tests passed.
+            let pass_status = match test.status {
+                Status::Success => status.success(),
+                Status::Error => {
+                    meant_to_error = true;
+                    !status.success()
+                }
+                Status::Signal => status.signal().is_some(),
+                Status::Int(i) => status.code() == Some(i),
+            };
 
-        // First, check whether the tests passed.
-        let pass_status = match test.status {
-            Status::Success => status.success(),
-            Status::Error => {
-                meant_to_error = true;
-                !status.success()
-            }
-            Status::Signal => status.signal().is_some(),
-            Status::Int(i) => status.code() == Some(i),
-        };
+            // Second, if a test failed, we want to print out everything which didn't match
+            // successfully (i.e. if the stderr test failed, print that out; but, equally, if
+            // stderr wasn't specified as a test, print it out, because the user can't
+            // otherwise know what it contains).
+            if !(pass_status
+                && stdin_remaining == 0
+                && match_stderr.is_ok()
+                && match_stdout.is_ok())
+            {
+                if let Some(rerun_if_status) = &test.rerun_if_status {
+                    let rerun = match rerun_if_status {
+                        Status::Success => status.success(),
+                        Status::Error => !status.success(),
+                        Status::Signal => status.signal().is_some(),
+                        Status::Int(i) => status.code() == Some(*i),
+                    };
+                    if rerun {
+                        continue;
+                    }
+                }
+                if test.rerun_if_stderr.is_some() {
+                    match rerun_if_stderr_fmb.build() {
+                        Ok(x) if x.matches(&stderr).is_ok() => continue,
+                        Ok(_) => {}
+                        Err(e) => {
+                            failure.stderr = Some(format!("FM error: {}", e));
+                            break 'a;
+                        }
+                    }
+                }
+                if test.rerun_if_stdout.is_some() {
+                    match rerun_if_stdout_fmb.build() {
+                        Ok(x) if x.matches(&stdout).is_ok() => continue,
+                        Ok(_) => {}
+                        Err(e) => {
+                            failure.stdout = Some(format!("FM error: {}", e));
+                            break 'a;
+                        }
+                    }
+                }
 
-        // Second, if a test failed, we want to print out everything which didn't match
-        // successfully (i.e. if the stderr test failed, print that out; but, equally, if
-        // stderr wasn't specified as a test, print it out, because the user can't
-        // otherwise know what it contains).
-        if !(pass_status && stdin_remaining == 0 && match_stderr.is_ok() && match_stdout.is_ok()) {
-            if !pass_status || failure.status.is_none() {
                 match test.status {
                     Status::Success | Status::Error => {
                         if status.success() {
@@ -771,31 +822,32 @@ fn run_tests(
                             }))
                     }
                 }
+
+                if match_stderr.is_err() || failure.stderr.is_none() {
+                    failure.stderr = Some(stderr);
+                }
+                if let Err(e) = match_stderr {
+                    failure.stderr_match = Some(e);
+                }
+
+                if match_stdout.is_err() || failure.stdout.is_none() {
+                    failure.stdout = Some(stdout);
+                }
+                if let Err(e) = match_stdout {
+                    failure.stdout_match = Some(e);
+                }
+
+                failure.stdin_remaining = stdin_remaining;
+
+                // If a sub-test failed, bail out immediately, otherwise subsequent sub-tests
+                // will overwrite the failure output!
+                break 'a;
             }
 
-            if match_stderr.is_err() || failure.stderr.is_none() {
-                failure.stderr = Some(stderr);
+            // If a command failed, and we weren't expecting it to, bail out immediately.
+            if !status.success() && meant_to_error {
+                break 'a;
             }
-            if let Err(e) = match_stderr {
-                failure.stderr_match = Some(e);
-            }
-
-            if match_stdout.is_err() || failure.stdout.is_none() {
-                failure.stdout = Some(stdout);
-            }
-            if let Err(e) = match_stdout {
-                failure.stdout_match = Some(e);
-            }
-
-            failure.stdin_remaining = stdin_remaining;
-
-            // If a sub-test failed, bail out immediately, otherwise subsequent sub-tests
-            // will overwrite the failure output!
-            break;
-        }
-
-        // If a command failed, and we weren't expecting it to, bail out immediately.
-        if !status.success() && meant_to_error {
             break;
         }
     }
@@ -841,7 +893,7 @@ fn run_tests(
 fn run_cmd(
     inner: Arc<LangTesterPooler>,
     test_fname: &str,
-    mut cmd: Command,
+    cmd: &mut Command,
     test: &TestCmd,
 ) -> (ExitStatus, usize, String, String) {
     // The basic sequence here is:


### PR DESCRIPTION
This PR adds support for rerunning tests if a) the test fails b) at least one of `rerun-if-{status, stderr, stdout}` matches.

Consider this test (which is included in the PR):

```python
# VM:
#   status: success
#   rerun-if-status: 42

import os, sys

cookie = os.path.join(os.environ["CARGO_MANIFEST_DIR"], "target", "tmp", "rerun_status_cookie")
i = 0
if os.path.exists(cookie):
    i = int(open(cookie, "r").read().strip()) + 1
    if i == 5:
        sys.exit(0)

open(cookie, "w").write(str(i))
sys.exit(42)
```

The first 4 times this test runs it will return with exit code 42, causing the test to be rerun. On the 5th time it will return with exit code 0.

The default number of times to rerun tests is arbitrarily set at 3, but users can override this.

Note that I have vaccillated several times over how to define this feature. At one point I thought it should be at the Rust-configuration level but, on reflection, that felt too fragile. If the user has lots of tests that should be rerun (e.g. if there's a network error) they're better off marking each one, since at least then forgetting to mark them as such will be spotted. In contrast, if there's a blanket application of rerun logic, it's more likely to accidentally cause errors to be suppressed.