### PR TITLE
Pretty print failures

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -439,7 +439,8 @@ impl LangTester {
             0
         };
 
-        let failures = Mutex::into_inner(Arc::try_unwrap(failures).unwrap()).unwrap();
+        let mut failures = Mutex::into_inner(Arc::try_unwrap(failures).unwrap()).unwrap();
+        failures.sort_by_key(|x| x.0.to_lowercase());
         self.pp_failures(
             &failures,
             max(test_files_len, failures.len()),

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -489,9 +489,9 @@ impl LangTester {
                     }
                 }
             }
-            eprintln!("\nfailures:");
+            eprint!("failures:");
             for (test_fname, _) in failures {
-                eprint!("    lang_tests::{}", test_fname);
+                eprint!("\n    lang_tests::{}", test_fname);
             }
         }
 


### PR DESCRIPTION
This PR is cosmetic, but makes it much easier to see which tests are failing. Each commit hopefully motivates it appropriately.

To give an example, before:

``
failures:
    lang_tests::float.newcg.c    lang_tests::float_consts.newcg.c    lang_tests::fp_to_si.newcg.c    lang_tests::float_add.newcg.c    lang_tests::double.newcg.c    lang_tests::float_mul.newcg.c    lang_tests::float_div.newcg.c    lang_tests::udiv.newcg.c    lang_tests::sdiv.newcg.c    lang_tests::fcmp_double.newcg.c    lang_tests::fcmp_float.newcg.c
```

and after:

```
failures:
    lang_tests::double.newcg.c
    lang_tests::fcmp_double.newcg.c
    lang_tests::fcmp_float.newcg.c
    lang_tests::float.newcg.c
    lang_tests::float_add.newcg.c
    lang_tests::float_consts.newcg.c
    lang_tests::float_div.newcg.c
    lang_tests::float_mul.newcg.c
    lang_tests::fp_to_si.newcg.c
    lang_tests::sdiv.newcg.c
    lang_tests::udiv.newcg.c
```